### PR TITLE
Change the Code to interface

### DIFF
--- a/code.go
+++ b/code.go
@@ -1,0 +1,27 @@
+package failure
+
+import "strconv"
+
+// Code represents an error code.
+// The package provides 2 types codes, StringCode and IntCode.
+type Code interface {
+	// ErrorCode returns an error code in string representation.
+	// Use this only for printing the code, not for comparing codes.
+	ErrorCode() string
+}
+
+// StringCode represents an error code in string.
+type StringCode string
+
+// ErrorCode implements Code.
+func (c StringCode) ErrorCode() string {
+	return string(c)
+}
+
+// IntCode represents an error code in int64.
+type IntCode int64
+
+// ErrorCode implements Code.
+func (c IntCode) ErrorCode() string {
+	return strconv.FormatInt(int64(c), 10)
+}

--- a/code_test.go
+++ b/code_test.go
@@ -1,0 +1,38 @@
+package failure_test
+
+import (
+	"testing"
+
+	"github.com/morikuni/failure"
+	"github.com/stretchr/testify/assert"
+)
+
+type CustomCode string
+
+func (c CustomCode) ErrorCode() string {
+	return string(c)
+}
+
+func TestCode(t *testing.T) {
+	const (
+		s failure.StringCode = "123"
+		i failure.IntCode    = 123
+		c CustomCode         = "123"
+
+		s2 failure.StringCode = "123"
+		i2 failure.IntCode    = 123
+		c2 CustomCode         = "123"
+	)
+
+	assert.Equal(t, "123", s.ErrorCode())
+	assert.Equal(t, "123", i.ErrorCode())
+	assert.Equal(t, "123", c.ErrorCode())
+
+	assert.Equal(t, s, s2)
+	assert.Equal(t, i, i2)
+	assert.Equal(t, c, c2)
+
+	assert.NotEqual(t, s, i)
+	assert.NotEqual(t, s, c)
+	assert.NotEqual(t, i, c)
+}

--- a/failure.go
+++ b/failure.go
@@ -15,7 +15,7 @@ var (
 	DefaultMessage = "An internal error has occurred. Please try it later or contact the developer."
 
 	// Unknown represents unknown error code.
-	Unknown Code = "unknown"
+	Unknown Code = StringCode("unknown")
 )
 
 // Info is key-value data.
@@ -56,13 +56,13 @@ func (f Failure) Error() string {
 		buf.WriteString(f.CallStack[0].Func())
 	}
 
-	if f.Code != "" {
+	if f.Code != nil {
 		if buf.Len() != 0 {
 			buf.WriteRune('(')
-			buf.WriteString(string(f.Code))
+			buf.WriteString(string(f.Code.ErrorCode()))
 			buf.WriteRune(')')
 		} else {
-			buf.WriteString(string(f.Code))
+			buf.WriteString(string(f.Code.ErrorCode()))
 		}
 	}
 
@@ -142,7 +142,7 @@ func Translate(err error, code Code) Failure {
 // Wrap wraps the error.
 func Wrap(err error) Failure {
 	return Failure{
-		"",
+		nil,
 		"",
 		Callers(1),
 		nil,
@@ -150,19 +150,15 @@ func Wrap(err error) Failure {
 	}
 }
 
-// Code represents an error code.
-// Define your application errors with this type.
-type Code string
-
 // CodeOf extracts Code from the error.
 // If the error does not contain any code, Unknown is returned.
 func CodeOf(err error) Code {
 	if err == nil {
-		return ""
+		return nil
 	}
 
 	if f, ok := err.(Failure); ok {
-		if f.Code != "" {
+		if f.Code != nil {
 			return f.Code
 		}
 		if f.Underlying != nil {

--- a/failure_test.go
+++ b/failure_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	TestCodeA failure.Code = "code_a"
-	TestCodeB failure.Code = "code_b"
+	TestCodeA failure.StringCode = "code_a"
+	TestCodeB failure.IntCode    = 1
 )
 
 func TestFailure(t *testing.T) {
@@ -52,7 +52,7 @@ func TestFailure(t *testing.T) {
 				"xxx",
 				[]failure.Info{{"zzz": true}},
 				35,
-				"TestFailure(code_b): TestFailure(code_a)",
+				"TestFailure(1): TestFailure(code_a)",
 			},
 		},
 		"overwrite": {
@@ -62,7 +62,7 @@ func TestFailure(t *testing.T) {
 				"aaa",
 				[]failure.Info{{"bbb": 1}, {"zzz": true}},
 				35,
-				"TestFailure(code_b): TestFailure(code_a)",
+				"TestFailure(1): TestFailure(code_a)",
 			},
 		},
 		"wrap": {
@@ -82,13 +82,13 @@ func TestFailure(t *testing.T) {
 				"aaa",
 				nil,
 				36,
-				"TestFailure(code_b): yyy",
+				"TestFailure(1): yyy",
 			},
 		},
 		"nil": {
 			Input{nil},
 			Expect{
-				"",
+				nil,
 				"",
 				nil,
 				0,
@@ -166,7 +166,7 @@ func TestFailure_Format(t *testing.T) {
 				"%#v",
 			},
 			Expect{
-				`failure.Failure{Code:"", Message:"hello", CallStack:\[\]failure.PC{.*}, Info:failure.Info\(nil\), Underlying:failure.Failure{.*}}`,
+				`failure.Failure{Code:failure.Code\(nil\), Message:"hello", CallStack:\[\]failure.PC{.*}, Info:failure.Info\(nil\), Underlying:failure.Failure{.*}}`,
 			},
 		},
 	}


### PR DESCRIPTION
Allow using custom error codes.

For example, create a temporary error code.

```go
package main

import (
	"fmt"

	"github.com/morikuni/failure"
)

type TemporaryError string

func (te TemporaryError) ErrorCode() string {
	return string(te)
}

func (te TemporaryError) Temporary() {}

func IsTemporary(err error) bool {
	c := failure.CodeOf(err)

	type check interface {
		Temporary()
	}

	_, isTemporary := c.(check)
	return isTemporary
}

func main() {
	e1 := failure.New(failure.IntCode(1))
	e2 := failure.New(TemporaryError("temp"))

	fmt.Println(IsTemporary(e1))
	// false
	fmt.Println(IsTemporary(e2))
	// true
}
```