### PR TITLE
Change the CallStack to interface

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           command: make test
       - run:
           name: coverage
-          command: go test -coverpkg=. -covermode=atomic -coverprofile=coverage.txt
+          command: make cover
       - run:
           name: upload coverage
           command: bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,12 @@ init:
 .PHONY: test
 test:
 	go test -v ./...
+
+.PHONY: cover
+cover:
+	go test -coverpkg=. -covermode=atomic -coverprofile=coverage.txt
+
+.PHONY: view-cover
+view-cover: cover
+	go tool cover -html coverage.txt
+

--- a/callstack.go
+++ b/callstack.go
@@ -10,9 +10,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-// CallStack represents call stack.
+// CallStack represents a call stack.
 type CallStack interface {
+	// HeadFrame returns a Frame of the where call stack is created.
 	HeadFrame() Frame
+	// Frames returns frames of the call stack.
 	Frames() []Frame
 }
 
@@ -50,7 +52,6 @@ func (cs callStack) Frames() []Frame {
 	return fs
 }
 
-// Format implements fmt.Formatter.
 func (cs callStack) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
@@ -98,11 +99,17 @@ func CallStackFromPkgErrors(st errors.StackTrace) CallStack {
 	return callStack{[]uintptr(pcs)}
 }
 
+// Frame represents a stack frame.
 type Frame interface {
+	// Path returns a full path to the file.
 	Path() string
+	// File returns a file name.
 	File() string
+	// Line returns a line number in the file.
 	Line() int
+	// Func returns a function name.
 	Func() string
+	// Pkg returns a package name of the function.
 	Pkg() string
 }
 
@@ -114,22 +121,18 @@ type frame struct {
 	function string
 }
 
-// Path returns a full path to the file for pc.
 func (f frame) Path() string {
 	return f.file
 }
 
-// File returns a file name for pc.
 func (f frame) File() string {
 	return filepath.Base(f.file)
 }
 
-// Line returns a line number for pc.
 func (f frame) Line() int {
 	return f.line
 }
 
-// Func returns a function name for pc.
 func (f frame) Func() string {
 	fs := strings.Split(path.Base(f.function), ".")
 	if len(fs) >= 1 {
@@ -138,13 +141,11 @@ func (f frame) Func() string {
 	return fs[0]
 }
 
-// Pkg returns a package name for pc.
 func (f frame) Pkg() string {
 	fs := strings.Split(path.Base(f.function), ".")
 	return fs[0]
 }
 
-// Format implements fmt.Formatter.
 func (f frame) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':

--- a/callstack_test.go
+++ b/callstack_test.go
@@ -58,15 +58,15 @@ func TestCallStackFromPkgErrors(t *testing.T) {
 	assert.Equal(t, fs[1].Pkg(), "failure_test")
 }
 
-func TestFormat(t *testing.T) {
+func TestCallStack_Format(t *testing.T) {
 	cs := X()
 
 	assert.Regexp(t,
-		`X: TestFormat: .*`,
+		`X: TestCallStack_Format: .*`,
 		fmt.Sprintf("%v", cs),
 	)
 	assert.Regexp(t,
-		`X: TestFormat: .*`,
+		`X: TestCallStack_Format: .*`,
 		fmt.Sprintf("%s", cs),
 	)
 	assert.Regexp(t,
@@ -75,12 +75,14 @@ func TestFormat(t *testing.T) {
 	)
 	assert.Regexp(t,
 		`\[X\] /.+/github.com/morikuni/failure/callstack_test.go:14
-\[TestFormat\] /.+/github.com/morikuni/failure/callstack_test.go:62
+\[TestCallStack_Format\] /.+/github.com/morikuni/failure/callstack_test.go:62
 \[.*`,
 		fmt.Sprintf("%+v", cs),
 	)
+}
 
-	f := cs.Frames()[0]
+func TestFrame_Format(t *testing.T) {
+	f := X().HeadFrame()
 
 	assert.Regexp(t,
 		`/.+/github.com/morikuni/failure/callstack_test.go:14`,
@@ -98,4 +100,33 @@ func TestFormat(t *testing.T) {
 		`\[X\] /.+/github.com/morikuni/failure/callstack_test.go:14`,
 		fmt.Sprintf("%+v", f),
 	)
+}
+
+func TestCallStack_Frames(t *testing.T) {
+	cs := X()
+	fs := cs.Frames()
+
+	assert.Equal(t, cs.Frames(), fs)
+
+	assert.Equal(t, 14, fs[0].Line())
+	assert.Equal(t, "X", fs[0].Func())
+
+	assert.Equal(t, 106, fs[1].Line())
+	assert.Equal(t, "TestCallStack_Frames", fs[1].Func())
+}
+
+func TestCallStack_HeadFrame(t *testing.T) {
+	cs := X()
+
+	assert.Equal(t, cs.Frames()[0], cs.HeadFrame())
+}
+
+func TestFrame(t *testing.T) {
+	f := X().HeadFrame()
+
+	assert.Equal(t, "X", f.Func())
+	assert.Equal(t, 14, f.Line())
+	assert.Equal(t, "callstack_test.go", f.File())
+	assert.Contains(t, f.Path(), "github.com/morikuni/failure/callstack_test.go")
+	assert.Equal(t, "failure_test", f.Pkg())
 }

--- a/callstack_test.go
+++ b/callstack_test.go
@@ -15,19 +15,19 @@ func X() failure.CallStack {
 }
 
 func TestCallers(t *testing.T) {
-	cs := X()
+	fs := X().Frames()
 
-	assert.Contains(t, cs[0].Path(), "github.com/morikuni/failure/callstack_test.go")
-	assert.Contains(t, cs[0].File(), "callstack_test.go")
-	assert.Equal(t, cs[0].Func(), "X")
-	assert.Equal(t, cs[0].Line(), 14)
-	assert.Equal(t, cs[0].Pkg(), "failure_test")
+	assert.Contains(t, fs[0].Path(), "github.com/morikuni/failure/callstack_test.go")
+	assert.Contains(t, fs[0].File(), "callstack_test.go")
+	assert.Equal(t, fs[0].Func(), "X")
+	assert.Equal(t, fs[0].Line(), 14)
+	assert.Equal(t, fs[0].Pkg(), "failure_test")
 
-	assert.Contains(t, cs[1].Path(), "github.com/morikuni/failure/callstack_test.go")
-	assert.Contains(t, cs[0].File(), "callstack_test.go")
-	assert.Equal(t, cs[1].Func(), "TestCallers")
-	assert.Equal(t, cs[1].Line(), 18)
-	assert.Equal(t, cs[1].Pkg(), "failure_test")
+	assert.Contains(t, fs[1].Path(), "github.com/morikuni/failure/callstack_test.go")
+	assert.Contains(t, fs[1].File(), "callstack_test.go")
+	assert.Equal(t, fs[1].Func(), "TestCallers")
+	assert.Equal(t, fs[1].Line(), 18)
+	assert.Equal(t, fs[1].Pkg(), "failure_test")
 }
 
 func Y() error {
@@ -43,58 +43,59 @@ func TestCallStackFromPkgErrors(t *testing.T) {
 	st, ok := err.(StackTracer)
 	require.True(t, ok)
 
-	cs := failure.CallStackFromPkgErrors(st.StackTrace())
+	fs := failure.CallStackFromPkgErrors(st.StackTrace()).Frames()
 
-	assert.Contains(t, cs[0].Path(), "github.com/morikuni/failure/callstack_test.go")
-	assert.Contains(t, cs[0].File(), "callstack_test.go")
-	assert.Equal(t, cs[0].Func(), "Y")
-	assert.Equal(t, cs[0].Line(), 34)
-	assert.Equal(t, cs[0].Pkg(), "failure_test")
+	assert.Contains(t, fs[0].Path(), "github.com/morikuni/failure/callstack_test.go")
+	assert.Contains(t, fs[0].File(), "callstack_test.go")
+	assert.Equal(t, fs[0].Func(), "Y")
+	assert.Equal(t, fs[0].Line(), 34)
+	assert.Equal(t, fs[0].Pkg(), "failure_test")
 
-	assert.Contains(t, cs[1].Path(), "github.com/morikuni/failure/callstack_test.go")
-	assert.Contains(t, cs[0].File(), "callstack_test.go")
-	assert.Equal(t, cs[1].Func(), "TestCallStackFromPkgErrors")
-	assert.Equal(t, cs[1].Line(), 42)
-	assert.Equal(t, cs[1].Pkg(), "failure_test")
+	assert.Contains(t, fs[1].Path(), "github.com/morikuni/failure/callstack_test.go")
+	assert.Contains(t, fs[1].File(), "callstack_test.go")
+	assert.Equal(t, fs[1].Func(), "TestCallStackFromPkgErrors")
+	assert.Equal(t, fs[1].Line(), 42)
+	assert.Equal(t, fs[1].Pkg(), "failure_test")
 }
 
 func TestFormat(t *testing.T) {
-	cs := X()[:2]
+	cs := X()
 
-	assert.Equal(t,
-		`X: TestFormat`,
+	assert.Regexp(t,
+		`X: TestFormat: .*`,
 		fmt.Sprintf("%v", cs),
 	)
-	assert.Equal(t,
-		`X: TestFormat`,
+	assert.Regexp(t,
+		`X: TestFormat: .*`,
 		fmt.Sprintf("%s", cs),
 	)
 	assert.Regexp(t,
-		`\[\]failure.Frame{/.+/github.com/morikuni/failure/callstack_test.go:14, /.+/github.com/morikuni/failure/callstack_test.go:62}`,
+		`\[\]failure.Frame{/.+/github.com/morikuni/failure/callstack_test.go:14, /.+/github.com/morikuni/failure/callstack_test.go:62, .*}`,
 		fmt.Sprintf("%#v", cs),
 	)
 	assert.Regexp(t,
 		`\[X\] /.+/github.com/morikuni/failure/callstack_test.go:14
-\[TestFormat\] /.+/github.com/morikuni/failure/callstack_test.go:62`,
+\[TestFormat\] /.+/github.com/morikuni/failure/callstack_test.go:62
+\[.*`,
 		fmt.Sprintf("%+v", cs),
 	)
 
-	pc := cs[0]
+	f := cs.Frames()[0]
 
 	assert.Regexp(t,
 		`/.+/github.com/morikuni/failure/callstack_test.go:14`,
-		fmt.Sprintf("%v", pc),
+		fmt.Sprintf("%v", f),
 	)
 	assert.Regexp(t,
 		`/.+/github.com/morikuni/failure/callstack_test.go:14`,
-		fmt.Sprintf("%s", pc),
+		fmt.Sprintf("%s", f),
 	)
 	assert.Regexp(t,
 		`/.+/github.com/morikuni/failure/callstack_test.go:14`,
-		fmt.Sprintf("%#v", pc),
+		fmt.Sprintf("%#v", f),
 	)
 	assert.Regexp(t,
 		`\[X\] /.+/github.com/morikuni/failure/callstack_test.go:14`,
-		fmt.Sprintf("%+v", pc),
+		fmt.Sprintf("%+v", f),
 	)
 }

--- a/failure.go
+++ b/failure.go
@@ -52,8 +52,8 @@ func (f Failure) WithInfo(info Info) Failure {
 func (f Failure) Error() string {
 	buf := &bytes.Buffer{}
 
-	if len(f.CallStack) != 0 {
-		buf.WriteString(f.CallStack[0].Func())
+	if f.CallStack != nil {
+		buf.WriteString(f.CallStack.HeadFrame().Func())
 	}
 
 	if f.Code != nil {
@@ -89,8 +89,8 @@ func (f Failure) Format(s fmt.State, verb rune) {
 				}
 			}
 			fmt.Fprint(s, "  CallStack:\n")
-			for _, pc := range CallStackOf(f) {
-				fmt.Fprintf(s, "    %+v\n", pc)
+			for _, f := range CallStackOf(f).Frames() {
+				fmt.Fprintf(s, "    %+v\n", f)
 			}
 		case s.Flag('#'):
 			// Re-define struct to remove Format method.

--- a/failure_test.go
+++ b/failure_test.go
@@ -187,3 +187,9 @@ func TestCauseOf(t *testing.T) {
 	pkgErr := errors.Wrap(base, "aaa")
 	assert.Equal(t, base, failure.CauseOf(failure.Wrap(pkgErr)))
 }
+
+func BenchmarkFailure(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		failure.Wrap(failure.Translate(failure.New(failure.StringCode("error")), failure.StringCode("failure")))
+	}
+}

--- a/failure_test.go
+++ b/failure_test.go
@@ -111,9 +111,10 @@ func TestFailure(t *testing.T) {
 
 			cs := failure.CallStackOf(test.Input.Err)
 			if test.Expect.StackLine != 0 {
-				require.NotEmpty(t, cs)
-				if !assert.Equal(t, test.Expect.StackLine, cs[0].Line()) {
-					t.Log(cs[0])
+				fs := cs.Frames()
+				require.NotEmpty(t, fs)
+				if !assert.Equal(t, test.Expect.StackLine, fs[0].Line()) {
+					t.Log(fs[0])
 				}
 			} else {
 				assert.Nil(t, cs)
@@ -156,7 +157,7 @@ func TestFailure_Format(t *testing.T) {
   Info:
     zzz = true
   CallStack:
-    \[TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:138
+    \[TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:139
     \[.*`,
 			},
 		},


### PR DESCRIPTION
Every Frame has a file path, function name, and line number.
Every CallStack has a list of Frames.
Failure chain contains some of CallStacks.

It allocates memory of `<size of a frame> * <size of call stack> * <length of failure chain>`, even if almost Frames are not used.

This PR reduces memory usage by lazy evaluation.

## benchmark

### on master

```
$ go test -bench . -benchmem -count 10
goos: darwin
goarch: amd64
pkg: github.com/morikuni/failure
BenchmarkFailure-4        200000              7070 ns/op            1968 B/op         21 allocs/op
BenchmarkFailure-4        200000              5260 ns/op            1968 B/op         21 allocs/op
BenchmarkFailure-4        300000              5215 ns/op            1968 B/op         21 allocs/op
BenchmarkFailure-4        300000              5187 ns/op            1968 B/op         21 allocs/op
BenchmarkFailure-4        300000              5251 ns/op            1968 B/op         21 allocs/op
BenchmarkFailure-4        300000              5191 ns/op            1968 B/op         21 allocs/op
BenchmarkFailure-4        200000              5213 ns/op            1968 B/op         21 allocs/op
BenchmarkFailure-4        300000              5302 ns/op            1968 B/op         21 allocs/op
BenchmarkFailure-4        300000              5277 ns/op            1968 B/op         21 allocs/op
BenchmarkFailure-4        300000              5465 ns/op            1968 B/op         21 allocs/op
PASS
ok      github.com/morikuni/failure     15.277s
```

### on this branch

```
$ go test -bench . -benchmem -count 10
goos: darwin
goarch: amd64
pkg: github.com/morikuni/failure
BenchmarkFailure-4        500000              2328 ns/op             864 B/op          6 allocs/op
BenchmarkFailure-4       1000000              1784 ns/op             864 B/op          6 allocs/op
BenchmarkFailure-4       1000000              1743 ns/op             864 B/op          6 allocs/op
BenchmarkFailure-4       1000000              1727 ns/op             864 B/op          6 allocs/op
BenchmarkFailure-4       1000000              1752 ns/op             864 B/op          6 allocs/op
BenchmarkFailure-4       1000000              1785 ns/op             864 B/op          6 allocs/op
BenchmarkFailure-4       1000000              1710 ns/op             864 B/op          6 allocs/op
BenchmarkFailure-4       1000000              1789 ns/op             864 B/op          6 allocs/op
BenchmarkFailure-4       1000000              1756 ns/op             864 B/op          6 allocs/op
BenchmarkFailure-4       1000000              1769 ns/op             864 B/op          6 allocs/op
PASS
ok      github.com/morikuni/failure     17.241s
```

3x faster and half memory usage.