### PR TITLE
Use functional option pattern instead of method chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,16 @@ import (
 
 // error codes for your application.
 const (
-	NotFound  failure.Code = "not_found"
-	Forbidden failure.Code = "forbidden"
+	NotFound  failure.StringCode = "not_found"
+	Forbidden failure.StringCode = "forbidden"
 )
 
 func GetACL(projectID, userID string) (acl interface{}, e error) {
 	notFound := true
 	if notFound {
-		return nil, failure.New(NotFound).WithInfo(failure.Info{"projectID": projectID, "userID": userID})
+		return nil, failure.New(NotFound,
+			failure.WithInfo(failure.Info{"projectID": projectID, "userID": userID}),
+		)
 	}
 	err := errors.New("error")
 	if err != nil {
@@ -66,9 +68,10 @@ func GetProject(projectID, userID string) (project interface{}, e error) {
 	if err != nil {
 		switch failure.CodeOf(err) {
 		case NotFound:
-			return nil, failure.Translate(err, Forbidden).
-				WithMessage("You have no grant to access the project.").
-				WithInfo(failure.Info{"additionalInfo": "hello"})
+			return nil, failure.Translate(err, Forbidden,
+				failure.WithMessage("You have no grant to access the project."),
+				failure.WithInfo(failure.Info{"additionalInfo": "hello"}),
+			)
 		default:
 			return nil, err
 		}
@@ -108,8 +111,8 @@ func HandleError(w http.ResponseWriter, err error) {
 	//     userID = 456
 	//   CallStack:
 	//     [GetACL] /go/src/github.com/morikuni/failure/example/main.go:21
-	//     [GetProject] /go/src/github.com/morikuni/failure/example/main.go:31
-	//     [Handler] /go/src/github.com/morikuni/failure/example/main.go:46
+	//     [GetProject] /go/src/github.com/morikuni/failure/example/main.go:33
+	//     [Handler] /go/src/github.com/morikuni/failure/example/main.go:49
 	//     [HandlerFunc.ServeHTTP] /usr/local/go/src/net/http/server.go:1918
 	//     [(*ServeMux).ServeHTTP] /usr/local/go/src/net/http/server.go:2254
 	//     [serverHandler.ServeHTTP] /usr/local/go/src/net/http/server.go:2619

--- a/failure.go
+++ b/failure.go
@@ -36,18 +36,6 @@ type Failure struct {
 	Underlying error
 }
 
-// WithMessage attaches a message to the failure.
-func (f Failure) WithMessage(message string) Failure {
-	f.Message = message
-	return f
-}
-
-// WithInfo attaches information to the failure.
-func (f Failure) WithInfo(info Info) Failure {
-	f.Info = info
-	return f
-}
-
 // Failure implements error.
 func (f Failure) Error() string {
 	buf := &bytes.Buffer{}
@@ -118,36 +106,32 @@ func (f Failure) Cause() error {
 }
 
 // New returns an application error.
-func New(code Code) Failure {
-	return Failure{
-		code,
-		"",
-		Callers(1),
-		nil,
-		nil,
-	}
+func New(code Code, opts ...Option) Failure {
+	return newFailure(nil, code, opts)
 }
 
 // Translate translates the error to an application error.
-func Translate(err error, code Code) Failure {
-	return Failure{
-		code,
-		"",
-		Callers(1),
-		nil,
-		err,
-	}
+func Translate(err error, code Code, opts ...Option) Failure {
+	return newFailure(err, code, opts)
 }
 
 // Wrap wraps the error.
-func Wrap(err error) Failure {
-	return Failure{
-		nil,
+func Wrap(err error, opts ...Option) Failure {
+	return newFailure(err, nil, opts)
+}
+
+func newFailure(err error, code Code, opts []Option) Failure {
+	f := Failure{
+		code,
 		"",
-		Callers(1),
+		Callers(2),
 		nil,
 		err,
 	}
+	for _, o := range opts {
+		o(&f)
+	}
+	return f
 }
 
 // CodeOf extracts Code from the error.

--- a/failure_test.go
+++ b/failure_test.go
@@ -32,11 +32,11 @@ func TestFailure(t *testing.T) {
 		Expect
 	}
 
-	base := failure.New(TestCodeA).WithMessage("xxx").WithInfo(failure.Info{"zzz": true})
+	base := failure.New(TestCodeA, failure.WithMessage("xxx"), failure.WithInfo(failure.Info{"zzz": true}))
 	pkgErr := errors.New("yyy")
 	tests := map[string]Test{
 		"new": {
-			Input{failure.New(TestCodeA).WithInfo(failure.Info{"aaa": 1})},
+			Input{failure.New(TestCodeA, failure.WithInfo(failure.Info{"aaa": 1}))},
 			Expect{
 				TestCodeA,
 				failure.DefaultMessage,
@@ -56,7 +56,7 @@ func TestFailure(t *testing.T) {
 			},
 		},
 		"overwrite": {
-			Input{failure.Translate(base, TestCodeB).WithMessage("aaa").WithInfo(failure.Info{"bbb": 1})},
+			Input{failure.Translate(base, TestCodeB, failure.WithMessage("aaa"), failure.WithInfo(failure.Info{"bbb": 1}))},
 			Expect{
 				TestCodeB,
 				"aaa",
@@ -76,7 +76,7 @@ func TestFailure(t *testing.T) {
 			},
 		},
 		"pkg/errors": {
-			Input{failure.Translate(pkgErr, TestCodeB).WithMessage("aaa")},
+			Input{failure.Translate(pkgErr, TestCodeB, failure.WithMessage("aaa"))},
 			Expect{
 				TestCodeB,
 				"aaa",
@@ -136,7 +136,7 @@ func TestFailure_Format(t *testing.T) {
 		Expect
 	}
 
-	base := failure.New(TestCodeA).WithMessage("xxx").WithInfo(failure.Info{"zzz": true})
+	base := failure.New(TestCodeA, failure.WithMessage("xxx"), failure.WithInfo(failure.Info{"zzz": true}))
 	tests := map[string]Test{
 		"v": {
 			Input{
@@ -163,7 +163,7 @@ func TestFailure_Format(t *testing.T) {
 		},
 		"#v": {
 			Input{
-				failure.Wrap(base).WithMessage("hello"),
+				failure.Wrap(base, failure.WithMessage("hello")),
 				"%#v",
 			},
 			Expect{

--- a/option.go
+++ b/option.go
@@ -1,0 +1,18 @@
+package failure
+
+// Option represents an optional parameter of failure.
+type Option func(*Failure)
+
+// WithMessage adds a message to a failure.
+func WithMessage(msg string) Option {
+	return func(f *Failure) {
+		f.Message = msg
+	}
+}
+
+// WithInfo adds info to a failure.
+func WithInfo(info Info) Option {
+	return func(f *Failure) {
+		f.Info = info
+	}
+}


### PR DESCRIPTION
to make it be more hard to change a value of the failure after creation by removing method chain. (to be more immutable)