### PR TITLE
Change the Option to interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ func GetACL(projectID, userID string) (acl interface{}, e error) {
 	notFound := true
 	if notFound {
 		return nil, failure.New(NotFound,
-			failure.WithInfo(failure.Info{"projectID": projectID, "userID": userID}),
+			failure.Info{"projectID": projectID, "userID": userID},
 		)
 	}
 	err := errors.New("error")
@@ -69,8 +69,8 @@ func GetProject(projectID, userID string) (project interface{}, e error) {
 		switch failure.CodeOf(err) {
 		case NotFound:
 			return nil, failure.Translate(err, Forbidden,
-				failure.WithMessage("You have no grant to access the project."),
-				failure.WithInfo(failure.Info{"additionalInfo": "hello"}),
+				failure.Message("You have no grant to access the project."),
+				failure.Info{"additionalInfo": "hello"},
 			)
 		default:
 			return nil, err

--- a/failure.go
+++ b/failure.go
@@ -18,9 +18,6 @@ var (
 	Unknown Code = StringCode("unknown")
 )
 
-// Info is key-value data.
-type Info map[string]interface{}
-
 // Failure is an error representing failure of something.
 type Failure struct {
 	// Code is an error code to handle the error in your source code.
@@ -131,7 +128,7 @@ func newFailure(err error, code Code, opts []Option) Failure {
 		err,
 	}
 	for _, o := range opts {
-		o(&f)
+		o.ApplyTo(&f)
 	}
 	return f
 }

--- a/failure_test.go
+++ b/failure_test.go
@@ -32,11 +32,11 @@ func TestFailure(t *testing.T) {
 		Expect
 	}
 
-	base := failure.New(TestCodeA, failure.WithMessage("xxx"), failure.WithInfo(failure.Info{"zzz": true}))
+	base := failure.New(TestCodeA, failure.Message("xxx"), failure.Info{"zzz": true})
 	pkgErr := errors.New("yyy")
 	tests := map[string]Test{
 		"new": {
-			Input{failure.New(TestCodeA, failure.WithInfo(failure.Info{"aaa": 1}))},
+			Input{failure.New(TestCodeA, failure.Info{"aaa": 1})},
 			Expect{
 				TestCodeA,
 				failure.DefaultMessage,
@@ -56,7 +56,7 @@ func TestFailure(t *testing.T) {
 			},
 		},
 		"overwrite": {
-			Input{failure.Translate(base, TestCodeB, failure.WithMessage("aaa"), failure.WithInfo(failure.Info{"bbb": 1}))},
+			Input{failure.Translate(base, TestCodeB, failure.Message("aaa"), failure.Info{"bbb": 1})},
 			Expect{
 				TestCodeB,
 				"aaa",
@@ -76,7 +76,7 @@ func TestFailure(t *testing.T) {
 			},
 		},
 		"pkg/errors": {
-			Input{failure.Translate(pkgErr, TestCodeB, failure.WithMessage("aaa"))},
+			Input{failure.Translate(pkgErr, TestCodeB, failure.Message("aaa"))},
 			Expect{
 				TestCodeB,
 				"aaa",
@@ -136,7 +136,7 @@ func TestFailure_Format(t *testing.T) {
 		Expect
 	}
 
-	base := failure.New(TestCodeA, failure.WithMessage("xxx"), failure.WithInfo(failure.Info{"zzz": true}))
+	base := failure.New(TestCodeA, failure.Message("xxx"), failure.Info{"zzz": true})
 	tests := map[string]Test{
 		"v": {
 			Input{
@@ -175,7 +175,7 @@ func TestFailure_Format(t *testing.T) {
 		},
 		"#v": {
 			Input{
-				failure.Wrap(base, failure.WithMessage("hello")),
+				failure.Wrap(base, failure.Message("hello")),
 				"%#v",
 			},
 			Expect{

--- a/option.go
+++ b/option.go
@@ -1,18 +1,29 @@
 package failure
 
 // Option represents an optional parameter of failure.
-type Option func(*Failure)
-
-// WithMessage adds a message to a failure.
-func WithMessage(msg string) Option {
-	return func(f *Failure) {
-		f.Message = msg
-	}
+type Option interface {
+	ApplyTo(*Failure)
 }
 
-// WithInfo adds info to a failure.
-func WithInfo(info Info) Option {
-	return func(f *Failure) {
-		f.Info = info
-	}
+// OptionFunc represents an option with function.
+type OptionFunc func(*Failure)
+
+// Apply implements the interface Option.
+func (of OptionFunc) ApplyTo(f *Failure) {
+	of(f)
+}
+
+// Message adds a message to a failure.
+func Message(msg string) Option {
+	return OptionFunc(func(f *Failure) {
+		f.Message = msg
+	})
+}
+
+// Info is key-value data.
+type Info map[string]interface{}
+
+// Apply implements the interface Option.
+func (i Info) ApplyTo(f *Failure) {
+	f.Info = i
 }

--- a/option.go
+++ b/option.go
@@ -8,7 +8,7 @@ type Option interface {
 // OptionFunc represents an option with function.
 type OptionFunc func(*Failure)
 
-// Apply implements the interface Option.
+// ApplyTo implements the interface Option.
 func (of OptionFunc) ApplyTo(f *Failure) {
 	of(f)
 }
@@ -23,7 +23,7 @@ func Message(msg string) Option {
 // Info is key-value data.
 type Info map[string]interface{}
 
-// Apply implements the interface Option.
+// ApplyTo implements the interface Option.
 func (i Info) ApplyTo(f *Failure) {
 	f.Info = i
 }


### PR DESCRIPTION
Now `failure.WithInfo` is not needed.