### PR TITLE
Return error interface instead of Failure struct

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,35 +2,47 @@
 
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "UT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:c40d65817cdd41fac9aa7af8bed56927bb2d6d47e4fea566a74880f5c2b1c41e"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "require"
+    "require",
   ]
+  pruneopts = "UT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "46b1e2f142877338234b6f6bc34a7d11e5bc08fb5e8248aad0c49a3f0953186e"
+  input-imports = [
+    "github.com/pkg/errors",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/failure.go
+++ b/failure.go
@@ -105,17 +105,20 @@ func (f Failure) Cause() error {
 }
 
 // New returns an application error.
-func New(code Code, opts ...Option) Failure {
+func New(code Code, opts ...Option) error {
 	return newFailure(nil, code, opts)
 }
 
 // Translate translates the error to an application error.
-func Translate(err error, code Code, opts ...Option) Failure {
+func Translate(err error, code Code, opts ...Option) error {
 	return newFailure(err, code, opts)
 }
 
 // Wrap wraps the error.
-func Wrap(err error, opts ...Option) Failure {
+func Wrap(err error, opts ...Option) error {
+	if err == nil {
+		return nil
+	}
 	return newFailure(err, nil, opts)
 }
 


### PR DESCRIPTION
fix #8

`Wrap` should return nil when an err is nil.

Since I don't use `Failure` struct directly in the most case, returning `error` is better.
The changes include breaking the current API, but  `failure` should be used in return statement that returns an error, so what require to users are just make minor changes. 
