### PR TITLE
Print package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,25 +114,25 @@ func HandleError(w http.ResponseWriter, err error) {
 	io.WriteString(w, failure.MessageOf(err))
 
 	fmt.Println(err)
-	// GetProject: code(forbidden): GetACL: code(not_found)
+	// main.GetProject: code(forbidden): main.GetACL: code(not_found)
 	fmt.Printf("%+v\n", err)
-	// [GetProject] /go/src/github.com/morikuni/failure/exmple/example.go:36
+	// [main.GetProject] /go/src/github.com/morikuni/failure/example/main.go:36
 	//     additional_info = hello
 	//     message("You have no grant to access the project.")
 	//     code(forbidden)
-	// [GetACL] /go/src/github.com/morikuni/failure/exmple/example.go:21
-	//     project_id = 123
-	//     user_id = 456
+	// [main.GetACL] /go/src/github.com/morikuni/failure/example/main.go:21
+	//     project_id =
+	//     user_id =
 	//     code(not_found)
 	// [CallStack]
-	//     [GetACL] /go/src/github.com/morikuni/failure/exmple/example.go:21
-	//     [GetProject] /go/src/github.com/morikuni/failure/exmple/example.go:33
-	//     [Handler] /go/src/github.com/morikuni/failure/exmple/example.go:47
-	//     [HandlerFunc.ServeHTTP] /usr/local/go/src/net/http/server.go:1964
-	//     [(*ServeMux).ServeHTTP] /usr/local/go/src/net/http/server.go:2361
-	//     [serverHandler.ServeHTTP] /usr/local/go/src/net/http/server.go:2741
-	//     [(*conn).serve] /usr/local/go/src/net/http/server.go:1847
-	//     [goexit] /usr/local/go/src/runtime/asm_amd64.s:1333
+	//     [main.GetACL] /go/src/github.com/morikuni/failure/example/main.go:21
+	//     [main.GetProject] /go/src/github.com/morikuni/failure/example/main.go:33
+	//     [main.Handler] /go/src/github.com/morikuni/failure/example/main.go:47
+	//     [http.HandlerFunc.ServeHTTP] /usr/local/go/src/net/http/server.go:1964
+	//     [http.(*ServeMux).ServeHTTP] /usr/local/go/src/net/http/server.go:2361
+	//     [http.serverHandler.ServeHTTP] /usr/local/go/src/net/http/server.go:2741
+	//     [http.(*conn).serve] /usr/local/go/src/net/http/server.go:1847
+	//     [runtime.goexit] /usr/local/go/src/runtime/asm_amd64.s:1333
 	fmt.Println(failure.CodeOf(err))
 	// forbidden
 	fmt.Println(failure.MessageOf(err))
@@ -140,7 +140,7 @@ func HandleError(w http.ResponseWriter, err error) {
 	fmt.Println(failure.DebugsOf(err))
 	// [map[additional_info:hello] map[project_id:123 user_id:456]]
 	fmt.Println(failure.CallStackOf(err))
-	// GetACL: GetProject: Handler: HandlerFunc.ServeHTTP: (*ServeMux).ServeHTTP: serverHandler.ServeHTTP: (*conn).serve: goexit
+	// main.GetACL: main.GetProject: main.Handler: http.HandlerFunc.ServeHTTP: http.(*ServeMux).ServeHTTP: http.serverHandler.ServeHTTP: http.(*conn).serve: goexit
 	fmt.Println(failure.CauseOf(err))
 	// code(not_found)
 }

--- a/callstack.go
+++ b/callstack.go
@@ -72,7 +72,7 @@ func (cs callStack) Format(s fmt.State, verb rune) {
 				return
 			}
 			for _, f := range fs[:l-1] {
-				fmt.Fprintf(s, "%s: ", f.Func())
+				fmt.Fprintf(s, "%s.%s: ", f.Pkg(), f.Func())
 			}
 			fmt.Fprintf(s, "%v", fs[l-1].Func())
 		}
@@ -159,7 +159,7 @@ func (f frame) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
 		if s.Flag('+') {
-			fmt.Fprintf(s, "[%s] ", f.Func())
+			fmt.Fprintf(s, "[%s.%s] ", f.Pkg(), f.Func())
 		}
 		fallthrough
 	case 's':

--- a/callstack_test.go
+++ b/callstack_test.go
@@ -55,11 +55,11 @@ func TestCallStack_Format(t *testing.T) {
 	cs := X()
 
 	assert.Regexp(t,
-		`X: TestCallStack_Format: .*`,
+		`failure_test.X: failure_test.TestCallStack_Format: .*`,
 		fmt.Sprintf("%v", cs),
 	)
 	assert.Regexp(t,
-		`X: TestCallStack_Format: .*`,
+		`failure_test.X: failure_test.TestCallStack_Format: .*`,
 		fmt.Sprintf("%s", cs),
 	)
 	assert.Regexp(t,
@@ -67,8 +67,8 @@ func TestCallStack_Format(t *testing.T) {
 		fmt.Sprintf("%#v", cs),
 	)
 	assert.Regexp(t,
-		`\[X\] /.+/github.com/morikuni/failure/callstack_test.go:13
-\[TestCallStack_Format\] /.+/github.com/morikuni/failure/callstack_test.go:55
+		`\[failure_test.X\] /.+/github.com/morikuni/failure/callstack_test.go:13
+\[failure_test.TestCallStack_Format\] /.+/github.com/morikuni/failure/callstack_test.go:55
 \[.*`,
 		fmt.Sprintf("%+v", cs),
 	)
@@ -90,7 +90,7 @@ func TestFrame_Format(t *testing.T) {
 		fmt.Sprintf("%#v", f),
 	)
 	assert.Regexp(t,
-		`\[X\] /.+/github.com/morikuni/failure/callstack_test.go:13`,
+		`\[failure_test.X\] /.+/github.com/morikuni/failure/callstack_test.go:13`,
 		fmt.Sprintf("%+v", f),
 	)
 }

--- a/failure_test.go
+++ b/failure_test.go
@@ -37,7 +37,7 @@ func TestFailure(t *testing.T) {
 			wantMessage:   "",
 			wantDebugs:    []failure.Debug{{"aaa": 1}},
 			wantStackLine: 33,
-			wantError:     "TestFailure: code(code_a)",
+			wantError:     "failure_test.TestFailure: code(code_a)",
 		},
 		"translate": {
 			err: failure.Translate(base, TestCodeB),
@@ -47,7 +47,7 @@ func TestFailure(t *testing.T) {
 			wantMessage:   "xxx",
 			wantDebugs:    []failure.Debug{{"zzz": true}},
 			wantStackLine: 20,
-			wantError:     "TestFailure: code(1): TestFailure: code(code_a)",
+			wantError:     "failure_test.TestFailure: code(1): failure_test.TestFailure: code(code_a)",
 		},
 		"overwrite": {
 			err: failure.Translate(base, TestCodeB, failure.Message("aaa"), failure.Debug{"bbb": 1}),
@@ -57,7 +57,7 @@ func TestFailure(t *testing.T) {
 			wantMessage:   "aaa",
 			wantDebugs:    []failure.Debug{{"bbb": 1}, {"zzz": true}},
 			wantStackLine: 20,
-			wantError:     "TestFailure: code(1): TestFailure: code(code_a)",
+			wantError:     "failure_test.TestFailure: code(1): failure_test.TestFailure: code(code_a)",
 		},
 		"wrap": {
 			err: failure.Wrap(io.EOF),
@@ -67,7 +67,7 @@ func TestFailure(t *testing.T) {
 			wantMessage:   "",
 			wantDebugs:    nil,
 			wantStackLine: 63,
-			wantError:     "TestFailure: " + io.EOF.Error(),
+			wantError:     "failure_test.TestFailure: " + io.EOF.Error(),
 		},
 		"wrap nil": {
 			err: failure.Wrap(nil),
@@ -87,7 +87,7 @@ func TestFailure(t *testing.T) {
 			wantMessage:   "aaa",
 			wantDebugs:    nil,
 			wantStackLine: 21,
-			wantError:     "TestFailure: code(1): yyy",
+			wantError:     "failure_test.TestFailure: code(1): yyy",
 		},
 		"nil": {
 			err: nil,
@@ -148,21 +148,21 @@ func TestFailure_Format(t *testing.T) {
 	e2 := failure.Translate(e1, TestCodeA, failure.Message("xxx"), failure.Debug{"zzz": true})
 	err := failure.Wrap(e2)
 
-	want := "TestFailure_Format: TestFailure_Format: code(code_a): yyy"
+	want := "failure_test.TestFailure_Format: failure_test.TestFailure_Format: code(code_a): yyy"
 	assert.Equal(t, want, fmt.Sprintf("%s", err))
 	assert.Equal(t, want, fmt.Sprintf("%v", err))
 
 	exp := `failure.formatter{error:failure.withCallStack{.*`
 	assert.Regexp(t, exp, fmt.Sprintf("%#v", err))
 
-	exp = `\[TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:149
-\[TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:148
+	exp = `\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:149
+\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:148
     zzz = true
     message\("xxx"\)
     code\(code_a\)
     error\("yyy"\)
 \[CallStack\]
-    \[TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:148
+    \[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:148
     \[.*`
 	assert.Regexp(t, exp, fmt.Sprintf("%+v", err))
 }

--- a/wrapper.go
+++ b/wrapper.go
@@ -133,7 +133,8 @@ type withCallStack struct {
 }
 
 func (w withCallStack) Error() string {
-	return fmt.Sprintf("%s: %s", w.callStack.HeadFrame().Func(), w.err.Error())
+	head := w.callStack.HeadFrame()
+	return fmt.Sprintf("%s.%s: %s", head.Pkg(), head.Func(), w.err.Error())
 }
 
 func (w withCallStack) UnwrapError() error {


### PR DESCRIPTION
An application may include a same/similar name for receivers/functions. (e.g. for receiver name `Service`, for function name `Contains`)
Printing package name is useful for the case. 

`user.Service` <=> `item.Service`
`strings.Contains` <=> `bytes.Contains`