### PR TITLE
Print type for each error

### DIFF
--- a/failure_test.go
+++ b/failure_test.go
@@ -160,7 +160,7 @@ func TestFailure_Format(t *testing.T) {
     zzz = true
     message\("xxx"\)
     code\(code_a\)
-    error\("yyy"\)
+    \*errors.errorString\("yyy"\)
 \[CallStack\]
     \[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:148
     \[.*`

--- a/wrapper.go
+++ b/wrapper.go
@@ -244,7 +244,7 @@ func (f formatter) Format(s fmt.State, verb rune) {
 		case formatter:
 			// do nothing
 		default:
-			fmt.Fprintf(s, "    error(%q)\n", err.Error())
+			fmt.Fprintf(s, "    %T(%q)\n", err, err.Error())
 		}
 	}
 


### PR DESCRIPTION
```
                                [failure_test.TestFailure_Format] /go/src/github.com/morikuni/failure/failure_test.go:148
                                    zzz = true
                                    message("xxx")
                                    code(code_a)
                                    errors("yyy")
```

become

```
                                [failure_test.TestFailure_Format] /go/src/github.com/morikuni/failure/failure_test.go:148
                                    zzz = true
                                    message("xxx")
                                    code(code_a)
                                    *errors.errorString("yyy")
```