### PR TITLE
Return bool from XXXOf functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,17 +101,32 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func HandleError(w http.ResponseWriter, err error) {
-	switch failure.CodeOf(err) {
-	case NotFound:
-		w.WriteHeader(http.StatusNotFound)
-	case Forbidden:
-		w.WriteHeader(http.StatusForbidden)
-	default:
-		w.WriteHeader(http.StatusInternalServerError)
+func getHTTPStatus(err error) int {
+	c, ok := failure.CodeOf(err)
+	if !ok {
+		return http.StatusInternalServerError
 	}
+	switch c {
+	case NotFound:
+		return http.StatusNotFound
+	case Forbidden:
+		return http.StatusForbidden
+	default:
+		return http.StatusInternalServerError
+	}
+}
 
-	io.WriteString(w, failure.MessageOf(err))
+func getMessage(err error) string {
+	msg, ok := failure.MessageOf(err)
+	if ok {
+		return msg
+	}
+	return "Error"
+}
+
+func HandleError(w http.ResponseWriter, err error) {
+	w.WriteHeader(getHTTPStatus(err))
+	io.WriteString(w, getMessage(err))
 
 	fmt.Println(err)
 	// main.GetProject: code(forbidden): main.GetACL: code(not_found)

--- a/callstack_test.go
+++ b/callstack_test.go
@@ -36,7 +36,9 @@ func Y() error {
 func TestCallStackFromPkgErrors(t *testing.T) {
 	err := Y()
 
-	fs := failure.CallStackOf(err).Frames()
+	cs, ok := failure.CallStackOf(err)
+	assert.True(t, ok)
+	fs := cs.Frames()
 
 	assert.Contains(t, fs[0].Path(), "github.com/morikuni/failure/callstack_test.go")
 	assert.Contains(t, fs[0].File(), "callstack_test.go")
@@ -63,12 +65,12 @@ func TestCallStack_Format(t *testing.T) {
 		fmt.Sprintf("%s", cs),
 	)
 	assert.Regexp(t,
-		`\[\]failure.Frame{/.+/github.com/morikuni/failure/callstack_test.go:13, /.+/github.com/morikuni/failure/callstack_test.go:55, .*}`,
+		`\[\]failure.Frame{/.+/github.com/morikuni/failure/callstack_test.go:13, /.+/github.com/morikuni/failure/callstack_test.go:57, .*}`,
 		fmt.Sprintf("%#v", cs),
 	)
 	assert.Regexp(t,
 		`\[failure_test.X\] /.+/github.com/morikuni/failure/callstack_test.go:13
-\[failure_test.TestCallStack_Format\] /.+/github.com/morikuni/failure/callstack_test.go:55
+\[failure_test.TestCallStack_Format\] /.+/github.com/morikuni/failure/callstack_test.go:57
 \[.*`,
 		fmt.Sprintf("%+v", cs),
 	)
@@ -104,7 +106,7 @@ func TestCallStack_Frames(t *testing.T) {
 	assert.Equal(t, 13, fs[0].Line())
 	assert.Equal(t, "X", fs[0].Func())
 
-	assert.Equal(t, 99, fs[1].Line())
+	assert.Equal(t, 101, fs[1].Line())
 	assert.Equal(t, "TestCallStack_Frames", fs[1].Func())
 }
 

--- a/code.go
+++ b/code.go
@@ -8,9 +8,10 @@ func Is(err error, codes ...Code) bool {
 		return false
 	}
 
-	c := CodeOf(err)
-	if c == nil {
-		return false
+	c, ok := CodeOf(err)
+	if !ok {
+		// continue process (don't return) to accept the case Is(err, nil).
+		c = nil
 	}
 
 	for i := range codes {

--- a/code_test.go
+++ b/code_test.go
@@ -1,6 +1,7 @@
 package failure_test
 
 import (
+	"errors"
 	"testing"
 
 	"io"
@@ -64,4 +65,7 @@ func TestIs(t *testing.T) {
 	assert.False(t, failure.Is(nil, A, B))
 	assert.False(t, failure.Is(io.EOF, A, B))
 	assert.False(t, failure.Is(errA))
+
+	assert.True(t, failure.Is(nil, nil))
+	assert.True(t, failure.Is(errors.New("error"), nil))
 }

--- a/failure.go
+++ b/failure.go
@@ -34,9 +34,9 @@ func (f Failure) Error() string {
 }
 
 // CodeOf extracts an error Code from the error.
-func CodeOf(err error) Code {
+func CodeOf(err error) (Code, bool) {
 	if err == nil {
-		return nil
+		return nil, false
 	}
 
 	type codeGetter interface {
@@ -47,11 +47,11 @@ func CodeOf(err error) Code {
 	for i.Next() {
 		err := i.Error()
 		if g, ok := err.(codeGetter); ok {
-			return g.GetCode()
+			return g.GetCode(), true
 		}
 	}
 
-	return nil
+	return nil, false
 }
 
 // New creates a Failure from error Code.

--- a/failure_test.go
+++ b/failure_test.go
@@ -119,8 +119,14 @@ func TestFailure(t *testing.T) {
 				assert.Error(t, test.err)
 			}
 
-			assert.Equal(t, test.wantCode, failure.CodeOf(test.err))
-			assert.Equal(t, test.wantMessage, failure.MessageOf(test.err))
+			code, ok := failure.CodeOf(test.err)
+			assert.Equal(t, test.wantCode != nil, ok)
+			assert.Equal(t, test.wantCode, code)
+
+			msg, ok := failure.MessageOf(test.err)
+			assert.Equal(t, test.wantMessage != "", ok)
+			assert.Equal(t, test.wantMessage, msg)
+
 			assert.Equal(t, test.wantDebugs, failure.DebugsOf(test.err))
 
 			if test.wantError != "" {
@@ -129,14 +135,16 @@ func TestFailure(t *testing.T) {
 				assert.Nil(t, test.err)
 			}
 
-			cs := failure.CallStackOf(test.err)
+			cs, ok := failure.CallStackOf(test.err)
 			if test.wantStackLine != 0 {
+				assert.True(t, ok)
 				fs := cs.Frames()
 				require.NotEmpty(t, fs)
 				if !assert.Equal(t, test.wantStackLine, fs[0].Line()) {
 					t.Log(fs[0])
 				}
 			} else {
+				assert.False(t, ok)
 				assert.Nil(t, cs)
 			}
 		})
@@ -155,14 +163,14 @@ func TestFailure_Format(t *testing.T) {
 	exp := `failure.formatter{error:failure.withCallStack{.*`
 	assert.Regexp(t, exp, fmt.Sprintf("%#v", err))
 
-	exp = `\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:149
-\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:148
+	exp = `\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:157
+\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:156
     zzz = true
     message\("xxx"\)
     code\(code_a\)
     \*errors.errorString\("yyy"\)
 \[CallStack\]
-    \[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:148
+    \[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:156
     \[.*`
 	assert.Regexp(t, exp, fmt.Sprintf("%+v", err))
 }


### PR DESCRIPTION
# Changes

XXXOf functions also return bool value.
Return true if data exists, false if no data exists.

Affected functions.

- `CodeOf`
- `MessageOf`
- `CallStackOf`

This PR breaks backward compatibility.

# Motivation

Enforce checking zero value.
For now, If we call XXXOf functions like `CodeOf(err).ErrorCode()`, It can panic!!
By adding bool into its returning value, developers must consider zero value.