### PR TITLE
Change Debug’s value type to string

### DIFF
--- a/failure_test.go
+++ b/failure_test.go
@@ -17,7 +17,7 @@ const (
 )
 
 func TestFailure(t *testing.T) {
-	base := failure.New(TestCodeA, failure.Message("xxx"), failure.Debug{"zzz": true})
+	base := failure.New(TestCodeA, failure.Message("xxx"), failure.Debug{"zzz": "true"})
 	pkgErr := errors.New("yyy")
 	tests := map[string]struct {
 		err error
@@ -30,12 +30,12 @@ func TestFailure(t *testing.T) {
 		wantError     string
 	}{
 		"new": {
-			err: failure.New(TestCodeA, failure.Debug{"aaa": 1}),
+			err: failure.New(TestCodeA, failure.Debug{"aaa": "1"}),
 
 			shouldNil:     false,
 			wantCode:      TestCodeA,
 			wantMessage:   "",
-			wantDebugs:    []failure.Debug{{"aaa": 1}},
+			wantDebugs:    []failure.Debug{{"aaa": "1"}},
 			wantStackLine: 33,
 			wantError:     "failure_test.TestFailure: code(code_a)",
 		},
@@ -45,17 +45,17 @@ func TestFailure(t *testing.T) {
 			shouldNil:     false,
 			wantCode:      TestCodeB,
 			wantMessage:   "xxx",
-			wantDebugs:    []failure.Debug{{"zzz": true}},
+			wantDebugs:    []failure.Debug{{"zzz": "true"}},
 			wantStackLine: 20,
 			wantError:     "failure_test.TestFailure: code(1): failure_test.TestFailure: code(code_a)",
 		},
 		"overwrite": {
-			err: failure.Translate(base, TestCodeB, failure.Message("aaa"), failure.Debug{"bbb": 1}),
+			err: failure.Translate(base, TestCodeB, failure.Message("aaa"), failure.Debug{"bbb": "1"}),
 
 			shouldNil:     false,
 			wantCode:      TestCodeB,
 			wantMessage:   "aaa",
-			wantDebugs:    []failure.Debug{{"bbb": 1}, {"zzz": true}},
+			wantDebugs:    []failure.Debug{{"bbb": "1"}, {"zzz": "true"}},
 			wantStackLine: 20,
 			wantError:     "failure_test.TestFailure: code(1): failure_test.TestFailure: code(code_a)",
 		},
@@ -145,7 +145,7 @@ func TestFailure(t *testing.T) {
 
 func TestFailure_Format(t *testing.T) {
 	e1 := fmt.Errorf("yyy")
-	e2 := failure.Translate(e1, TestCodeA, failure.Message("xxx"), failure.Debug{"zzz": true})
+	e2 := failure.Translate(e1, TestCodeA, failure.Message("xxx"), failure.Debug{"zzz": "true"})
 	err := failure.Wrap(e2)
 
 	want := "failure_test.TestFailure_Format: failure_test.TestFailure_Format: code(code_a): yyy"

--- a/wrapper.go
+++ b/wrapper.go
@@ -73,7 +73,7 @@ func MessageOf(err error) string {
 
 // Debug is a key-value data appended to an error
 // for debugging purpose.
-type Debug map[string]interface{}
+type Debug map[string]string
 
 // WrapError implements the Wrapper interface.
 func (d Debug) WrapError(err error) error {
@@ -235,7 +235,7 @@ func (f formatter) Format(s fmt.State, verb rune) {
 		case debugger:
 			debug := t.GetDebug()
 			for k, v := range debug {
-				fmt.Fprintf(s, "    %s = %v\n", k, v)
+				fmt.Fprintf(s, "    %s = %s\n", k, v)
 			}
 		case messenger:
 			fmt.Fprintf(s, "    message(%q)\n", t.GetMessage())


### PR DESCRIPTION
# Changes

Change Debug’s value type from `interface{}` to `string` .

# Motivation

`interface{}` is too ambiguous for printing logs correctly.