### PR TITLE
v0.9.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 test:
-	GO111MODULE=on go test -v ./...
+	GO111MODULE=on go test -v ./... -count 1
 
 .PHONY: cover
 cover:

--- a/README.md
+++ b/README.md
@@ -61,15 +61,15 @@ import (
 
 // error codes for your application.
 const (
-	NotFound  failure.StringCode = "not_found"
-	Forbidden failure.StringCode = "forbidden"
+	NotFound  failure.StringCode = "NotFound"
+	Forbidden failure.StringCode = "Forbidden"
 )
 
 func GetACL(projectID, userID string) (acl interface{}, e error) {
 	notFound := true
 	if notFound {
 		return nil, failure.New(NotFound,
-			failure.Debug{"project_id": projectID, "user_id": userID},
+			failure.MessageKV{"project_id": projectID, "user_id": userID},
 		)
 	}
 	err := errors.New("error")
@@ -84,8 +84,8 @@ func GetProject(projectID, userID string) (project interface{}, e error) {
 	if err != nil {
 		if failure.Is(err, NotFound) {
 			return nil, failure.Translate(err, Forbidden,
-				failure.Message("You have no grant to access the project."),
-				failure.Debug{"additional_info": "hello"},
+				failure.Message("no acl exists"),
+				failure.MessageKV{"additional_info": "hello"},
 			)
 		}
 		return nil, failure.Wrap(err)
@@ -129,16 +129,16 @@ func HandleError(w http.ResponseWriter, err error) {
 	io.WriteString(w, getMessage(err))
 
 	fmt.Println(err)
-	// main.GetProject: code(forbidden): main.GetACL: code(not_found)
+	// main.GetProject: no acl exists: additional_info=hello: code(Forbidden): main.GetACL: project_id=123 user_id=456: code(NotFound)
 	fmt.Printf("%+v\n", err)
 	// [main.GetProject] /go/src/github.com/morikuni/failure/example/main.go:36
+	//     message("no acl exists")
 	//     additional_info = hello
-	//     message("You have no grant to access the project.")
-	//     code(forbidden)
+	//     code(Forbidden)
 	// [main.GetACL] /go/src/github.com/morikuni/failure/example/main.go:21
-	//     project_id =
-	//     user_id =
-	//     code(not_found)
+	//     project_id = 123
+	//     user_id = 456
+	//     code(NotFound)
 	// [CallStack]
 	//     [main.GetACL] /go/src/github.com/morikuni/failure/example/main.go:21
 	//     [main.GetProject] /go/src/github.com/morikuni/failure/example/main.go:33
@@ -149,26 +149,25 @@ func HandleError(w http.ResponseWriter, err error) {
 	//     [http.(*conn).serve] /usr/local/go/src/net/http/server.go:1847
 	//     [runtime.goexit] /usr/local/go/src/runtime/asm_amd64.s:1333
 	fmt.Println(failure.CodeOf(err))
-	// forbidden
+	// Forbidden true
 	fmt.Println(failure.MessageOf(err))
-	// You have no grant to access the project.
-	fmt.Println(failure.DebugsOf(err))
-	// [map[additional_info:hello] map[project_id:123 user_id:456]]
+	// no acl exists true
 	fmt.Println(failure.CallStackOf(err))
-	// main.GetACL: main.GetProject: main.Handler: http.HandlerFunc.ServeHTTP: http.(*ServeMux).ServeHTTP: http.serverHandler.ServeHTTP: http.(*conn).serve: goexit
+	// main.GetACL: main.GetProject: main.Handler: http.HandlerFunc.ServeHTTP: http.(*ServeMux).ServeHTTP: http.serverHandler.ServeHTTP: http.(*conn).serve: goexit true
 	fmt.Println(failure.CauseOf(err))
-	// code(not_found)
+	// code(NotFound)
 }
 
 func main() {
 	http.HandleFunc("/", Handler)
 	http.ListenAndServe(":8080", nil)
 	// $ http "localhost:8080/?projectID=123&userID=456"
-	// HTTP/1.1 403 Forbidden
-	// Content-Length: 40
-	// Content-Type: text/plain; charset=utf-8
-	// Date: Tue, 19 Jun 2018 02:56:32 GMT
 	//
-	// You have no grant to access the project.
+	// HTTP/1.1 403 Forbidden
+	// Content-Length: 13
+	// Content-Type: text/plain; charset=utf-8
+	// Date: Sat, 16 Feb 2019 14:02:30 GMT
+	//
+	// no acl exists
 }
 ```

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ func GetACL(projectID, userID string) (acl interface{}, e error) {
 			failure.MessageKV{"project_id": projectID, "user_id": userID},
 		)
 	}
-	err := errors.New("error")
+	err := failure.Unexpected("unexpected error")
 	if err != nil {
 		return nil, failure.Wrap(err)
 	}

--- a/code.go
+++ b/code.go
@@ -22,11 +22,8 @@ func Is(err error, codes ...Code) bool {
 	return false
 }
 
-// Code represents an error Code.
-// The code should not have internal state, so it should be
-// defined as a variable.
-// StringCode or IntCode are recommended if you don't need
-// custom behavior on the code.
+// Code represents an error code of the error.
+// The code should be able to be compared by == operator.
 type Code interface {
 	// ErrorCode returns an error Code in string representation.
 	ErrorCode() string

--- a/code.go
+++ b/code.go
@@ -25,7 +25,7 @@ func Is(err error, codes ...Code) bool {
 // Code represents an error code of the error.
 // The code should be able to be compared by == operator.
 type Code interface {
-	// ErrorCode returns an error Code in string representation.
+	// ErrorCode returns an error code in string representation.
 	ErrorCode() string
 }
 
@@ -37,7 +37,7 @@ func (c StringCode) ErrorCode() string {
 	return string(c)
 }
 
-// IntCode represents an error Code in int64.
+// IntCode represents an error code in int64.
 type IntCode int64
 
 // ErrorCode implements the Code interface.

--- a/failure.go
+++ b/failure.go
@@ -29,7 +29,7 @@ func CodeOf(err error) (Code, bool) {
 	return nil, false
 }
 
-// New creates a error from error Code.
+// New creates an error from error Code.
 func New(code Code, wrappers ...Wrapper) error {
 	return Custom(Custom(NewFailure(code), wrappers...), WithFormatter(), WithCallStackSkip(1))
 }
@@ -59,6 +59,22 @@ func Custom(err error, wrappers ...Wrapper) error {
 		err = wrappers[i].WrapError(err)
 	}
 	return err
+}
+
+type fundamental string
+
+func (e fundamental) Error() string {
+	return string(e)
+}
+
+func (e fundamental) GetMessage() string {
+	return string(e)
+}
+
+// Fundamental creates an error from string without error code.
+// The returned error should be kind of internal or unknown error.
+func Fundamental(msg string, wrappers ...Wrapper) error {
+	return Custom(Custom(fundamental(msg), wrappers...), WithFormatter(), WithCallStackSkip(1))
 }
 
 // NewFailure returns Failure without any wrappers.

--- a/failure.go
+++ b/failure.go
@@ -4,7 +4,6 @@ package failure
 
 import (
 	"fmt"
-	"strings"
 )
 
 // Failure represents an error with error code.
@@ -94,9 +93,8 @@ func (f *withCode) GetCode() Code {
 }
 
 func (f *withCode) Error() string {
-	msg := fmt.Sprintf("code(%s)", f.code.ErrorCode())
-	if f.underlying != nil {
-		msg = strings.Join([]string{msg, f.underlying.Error()}, ": ")
+	if f.underlying == nil {
+		return fmt.Sprintf("code(%s)", f.code.ErrorCode())
 	}
-	return msg
+	return fmt.Sprintf("code(%s): %s", f.code.ErrorCode(), f.underlying)
 }

--- a/failure.go
+++ b/failure.go
@@ -32,7 +32,6 @@ func CodeOf(err error) (Code, bool) {
 
 // New creates a error from error Code.
 func New(code Code, wrappers ...Wrapper) error {
-	return Custom(Custom(newFailure(code), wrappers...), WithFormatter(), WithCallStackSkip(1))
 	return Custom(Custom(NewFailure(code), wrappers...), WithFormatter(), WithCallStackSkip(1))
 }
 
@@ -63,10 +62,13 @@ func Custom(err error, wrappers ...Wrapper) error {
 	return err
 }
 
+// NewFailure returns Failure without any wrappers.
 func NewFailure(code Code) Failure {
 	return &withCode{code: code}
 }
 
+// WithCode appends code to an error.
+// You don't have to use this directly, unless using function Custom.
 func WithCode(code Code) Wrapper {
 	return WrapperFunc(func(err error) error {
 		return &withCode{code, err}

--- a/failure.go
+++ b/failure.go
@@ -12,7 +12,7 @@ type Failure interface {
 	GetCode() Code
 }
 
-// CodeOf extracts an error Code from the error.
+// CodeOf extracts an error code from the error.
 func CodeOf(err error) (Code, bool) {
 	if err == nil {
 		return nil, false
@@ -29,7 +29,7 @@ func CodeOf(err error) (Code, bool) {
 	return nil, false
 }
 
-// New creates an error from error Code.
+// New creates an error from error code.
 func New(code Code, wrappers ...Wrapper) error {
 	return Custom(Custom(NewFailure(code), wrappers...), WithFormatter(), WithCallStackSkip(1))
 }

--- a/failure.go
+++ b/failure.go
@@ -62,6 +62,8 @@ func Custom(err error, wrappers ...Wrapper) error {
 }
 
 // NewFailure returns Failure without any wrappers.
+// You don't have to use this directly, unless using function Custom.
+// Probably, you can use New instead of this.
 func NewFailure(code Code) Failure {
 	return &withCode{code: code}
 }

--- a/failure.go
+++ b/failure.go
@@ -33,6 +33,7 @@ func CodeOf(err error) (Code, bool) {
 // New creates a error from error Code.
 func New(code Code, wrappers ...Wrapper) error {
 	return Custom(Custom(newFailure(code), wrappers...), WithFormatter(), WithCallStackSkip(1))
+	return Custom(Custom(NewFailure(code), wrappers...), WithFormatter(), WithCallStackSkip(1))
 }
 
 // Translate translates err to an error with given code.
@@ -62,7 +63,7 @@ func Custom(err error, wrappers ...Wrapper) error {
 	return err
 }
 
-func newFailure(code Code) Failure {
+func NewFailure(code Code) Failure {
 	return &withCode{code: code}
 }
 

--- a/failure.go
+++ b/failure.go
@@ -61,20 +61,20 @@ func Custom(err error, wrappers ...Wrapper) error {
 	return err
 }
 
-type fundamental string
+type unexpected string
 
-func (e fundamental) Error() string {
+func (e unexpected) Error() string {
 	return string(e)
 }
 
-func (e fundamental) GetMessage() string {
+func (e unexpected) GetMessage() string {
 	return string(e)
 }
 
-// Fundamental creates an error from string without error code.
+// Unexpected creates an error from message without error code.
 // The returned error should be kind of internal or unknown error.
-func Fundamental(msg string, wrappers ...Wrapper) error {
-	return Custom(Custom(fundamental(msg), wrappers...), WithFormatter(), WithCallStackSkip(1))
+func Unexpected(msg string, wrappers ...Wrapper) error {
+	return Custom(Custom(unexpected(msg), wrappers...), WithFormatter(), WithCallStackSkip(1))
 }
 
 // NewFailure returns Failure without any wrappers.

--- a/failure_test.go
+++ b/failure_test.go
@@ -100,6 +100,15 @@ func TestFailure(t *testing.T) {
 			wantStackLine: 0,
 			wantError:     io.EOF.Error(),
 		},
+		"fundamental": {
+			err: failure.Fundamental("fundamental error", failure.MessageKV{"aaa": "1"}),
+
+			shouldNil:     false,
+			wantCode:      nil,
+			wantMessage:   "fundamental error",
+			wantStackLine: 104,
+			wantError:     "failure_test.TestFailure: aaa=1: fundamental error",
+		},
 	}
 
 	for title, test := range tests {
@@ -141,25 +150,26 @@ func TestFailure(t *testing.T) {
 }
 
 func TestFailure_Format(t *testing.T) {
-	e1 := fmt.Errorf("yyy")
+	e1 := failure.Fundamental("yyy")
 	e2 := failure.Translate(e1, TestCodeA, failure.Message("xxx"), failure.MessageKV{"zzz": "true"})
 	err := failure.Wrap(e2)
 
-	want := "failure_test.TestFailure_Format: failure_test.TestFailure_Format: xxx: zzz=true: code(code_a): yyy"
+	want := "failure_test.TestFailure_Format: failure_test.TestFailure_Format: xxx: zzz=true: code(code_a): failure_test.TestFailure_Format: yyy"
 	assert.Equal(t, want, fmt.Sprintf("%s", err))
 	assert.Equal(t, want, fmt.Sprintf("%v", err))
 
 	exp := `failure.formatter{error:failure.withCallStack{.*`
 	assert.Regexp(t, exp, fmt.Sprintf("%#v", err))
 
-	exp = `\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:146
-\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:145
+	exp = `\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:155
+\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:154
     message\("xxx"\)
     zzz = true
     code\(code_a\)
-    \*errors.errorString\("yyy"\)
+\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:153
+    message\("yyy"\)
 \[CallStack\]
-    \[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:145
+    \[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:153
     \[.*`
 	assert.Regexp(t, exp, fmt.Sprintf("%+v", err))
 }

--- a/failure_test.go
+++ b/failure_test.go
@@ -150,11 +150,11 @@ func TestFailure(t *testing.T) {
 }
 
 func TestFailure_Format(t *testing.T) {
-	e1 := failure.Fundamental("yyy")
+	e1 := fmt.Errorf("yyy")
 	e2 := failure.Translate(e1, TestCodeA, failure.Message("xxx"), failure.MessageKV{"zzz": "true"})
 	err := failure.Wrap(e2)
 
-	want := "failure_test.TestFailure_Format: failure_test.TestFailure_Format: xxx: zzz=true: code(code_a): failure_test.TestFailure_Format: yyy"
+	want := "failure_test.TestFailure_Format: failure_test.TestFailure_Format: xxx: zzz=true: code(code_a): yyy"
 	assert.Equal(t, want, fmt.Sprintf("%s", err))
 	assert.Equal(t, want, fmt.Sprintf("%v", err))
 
@@ -166,10 +166,9 @@ func TestFailure_Format(t *testing.T) {
     message\("xxx"\)
     zzz = true
     code\(code_a\)
-\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:153
-    message\("yyy"\)
+    \*errors.errorString\("yyy"\)
 \[CallStack\]
-    \[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:153
+    \[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:154
     \[.*`
 	assert.Regexp(t, exp, fmt.Sprintf("%+v", err))
 }

--- a/failure_test.go
+++ b/failure_test.go
@@ -50,14 +50,14 @@ func TestFailure(t *testing.T) {
 			wantError:     "failure_test.TestFailure: code(1): failure_test.TestFailure: xxx: code(code_a)",
 		},
 		"overwrite": {
-			err: failure.Translate(base, TestCodeB, failure.Message("aaa"), failure.Debug{"bbb": "1"}),
+			err: failure.Translate(base, TestCodeB, failure.Messagef("aaa: %s", "bbb"), failure.Debug{"bbb": "1"}),
 
 			shouldNil:     false,
 			wantCode:      TestCodeB,
-			wantMessage:   "aaa",
+			wantMessage:   "aaa: bbb",
 			wantDebugs:    []failure.Debug{{"bbb": "1"}, {"zzz": "true"}},
 			wantStackLine: 20,
-			wantError:     "failure_test.TestFailure: aaa: code(1): failure_test.TestFailure: xxx: code(code_a)",
+			wantError:     "failure_test.TestFailure: aaa: bbb: code(1): failure_test.TestFailure: xxx: code(code_a)",
 		},
 		"wrap": {
 			err: failure.Wrap(io.EOF),

--- a/failure_test.go
+++ b/failure_test.go
@@ -165,8 +165,8 @@ func TestFailure_Format(t *testing.T) {
 
 	exp = `\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:157
 \[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:156
-    zzz = true
     message\("xxx"\)
+    zzz = true
     code\(code_a\)
     \*errors.errorString\("yyy"\)
 \[CallStack\]

--- a/failure_test.go
+++ b/failure_test.go
@@ -100,14 +100,14 @@ func TestFailure(t *testing.T) {
 			wantStackLine: 0,
 			wantError:     io.EOF.Error(),
 		},
-		"fundamental": {
-			err: failure.Fundamental("fundamental error", failure.MessageKV{"aaa": "1"}),
+		"unexpected": {
+			err: failure.Unexpected("unexpected error", failure.MessageKV{"aaa": "1"}),
 
 			shouldNil:     false,
 			wantCode:      nil,
-			wantMessage:   "fundamental error",
+			wantMessage:   "unexpected error",
 			wantStackLine: 104,
-			wantError:     "failure_test.TestFailure: aaa=1: fundamental error",
+			wantError:     "failure_test.TestFailure: aaa=1: unexpected error",
 		},
 	}
 

--- a/failure_test.go
+++ b/failure_test.go
@@ -47,7 +47,7 @@ func TestFailure(t *testing.T) {
 			wantMessage:   "xxx",
 			wantDebugs:    []failure.Debug{{"zzz": "true"}},
 			wantStackLine: 20,
-			wantError:     "failure_test.TestFailure: code(1): failure_test.TestFailure: code(code_a)",
+			wantError:     "failure_test.TestFailure: code(1): failure_test.TestFailure: xxx: code(code_a)",
 		},
 		"overwrite": {
 			err: failure.Translate(base, TestCodeB, failure.Message("aaa"), failure.Debug{"bbb": "1"}),
@@ -57,7 +57,7 @@ func TestFailure(t *testing.T) {
 			wantMessage:   "aaa",
 			wantDebugs:    []failure.Debug{{"bbb": "1"}, {"zzz": "true"}},
 			wantStackLine: 20,
-			wantError:     "failure_test.TestFailure: code(1): failure_test.TestFailure: code(code_a)",
+			wantError:     "failure_test.TestFailure: aaa: code(1): failure_test.TestFailure: xxx: code(code_a)",
 		},
 		"wrap": {
 			err: failure.Wrap(io.EOF),
@@ -87,7 +87,7 @@ func TestFailure(t *testing.T) {
 			wantMessage:   "aaa",
 			wantDebugs:    nil,
 			wantStackLine: 21,
-			wantError:     "failure_test.TestFailure: code(1): yyy",
+			wantError:     "failure_test.TestFailure: aaa: code(1): yyy",
 		},
 		"nil": {
 			err: nil,
@@ -156,7 +156,7 @@ func TestFailure_Format(t *testing.T) {
 	e2 := failure.Translate(e1, TestCodeA, failure.Message("xxx"), failure.Debug{"zzz": "true"})
 	err := failure.Wrap(e2)
 
-	want := "failure_test.TestFailure_Format: failure_test.TestFailure_Format: code(code_a): yyy"
+	want := "failure_test.TestFailure_Format: failure_test.TestFailure_Format: xxx: code(code_a): yyy"
 	assert.Equal(t, want, fmt.Sprintf("%s", err))
 	assert.Equal(t, want, fmt.Sprintf("%v", err))
 

--- a/failure_test.go
+++ b/failure_test.go
@@ -17,7 +17,7 @@ const (
 )
 
 func TestFailure(t *testing.T) {
-	base := failure.New(TestCodeA, failure.Message("xxx"), failure.Debug{"zzz": "true"})
+	base := failure.New(TestCodeA, failure.Message("xxx"), failure.MessageKV{"zzz": "true"})
 	pkgErr := errors.New("yyy")
 	tests := map[string]struct {
 		err error
@@ -25,19 +25,17 @@ func TestFailure(t *testing.T) {
 		shouldNil     bool
 		wantCode      failure.Code
 		wantMessage   string
-		wantDebugs    []failure.Debug
 		wantStackLine int
 		wantError     string
 	}{
 		"new": {
-			err: failure.New(TestCodeA, failure.Debug{"aaa": "1"}),
+			err: failure.New(TestCodeA, failure.MessageKV{"aaa": "1"}),
 
 			shouldNil:     false,
 			wantCode:      TestCodeA,
 			wantMessage:   "",
-			wantDebugs:    []failure.Debug{{"aaa": "1"}},
-			wantStackLine: 33,
-			wantError:     "failure_test.TestFailure: code(code_a)",
+			wantStackLine: 32,
+			wantError:     "failure_test.TestFailure: aaa=1: code(code_a)",
 		},
 		"translate": {
 			err: failure.Translate(base, TestCodeB),
@@ -45,19 +43,17 @@ func TestFailure(t *testing.T) {
 			shouldNil:     false,
 			wantCode:      TestCodeB,
 			wantMessage:   "xxx",
-			wantDebugs:    []failure.Debug{{"zzz": "true"}},
 			wantStackLine: 20,
-			wantError:     "failure_test.TestFailure: code(1): failure_test.TestFailure: xxx: code(code_a)",
+			wantError:     "failure_test.TestFailure: code(1): failure_test.TestFailure: xxx: zzz=true: code(code_a)",
 		},
 		"overwrite": {
-			err: failure.Translate(base, TestCodeB, failure.Messagef("aaa: %s", "bbb"), failure.Debug{"bbb": "1"}),
+			err: failure.Translate(base, TestCodeB, failure.Messagef("aaa: %s", "bbb"), failure.MessageKV{"ccc": "1", "ddd": "2"}),
 
 			shouldNil:     false,
 			wantCode:      TestCodeB,
 			wantMessage:   "aaa: bbb",
-			wantDebugs:    []failure.Debug{{"bbb": "1"}, {"zzz": "true"}},
 			wantStackLine: 20,
-			wantError:     "failure_test.TestFailure: aaa: bbb: code(1): failure_test.TestFailure: xxx: code(code_a)",
+			wantError:     "failure_test.TestFailure: aaa: bbb: ccc=1 ddd=2: code(1): failure_test.TestFailure: xxx: zzz=true: code(code_a)",
 		},
 		"wrap": {
 			err: failure.Wrap(io.EOF),
@@ -65,8 +61,7 @@ func TestFailure(t *testing.T) {
 			shouldNil:     false,
 			wantCode:      nil,
 			wantMessage:   "",
-			wantDebugs:    nil,
-			wantStackLine: 63,
+			wantStackLine: 59,
 			wantError:     "failure_test.TestFailure: " + io.EOF.Error(),
 		},
 		"wrap nil": {
@@ -75,7 +70,6 @@ func TestFailure(t *testing.T) {
 			shouldNil:     true,
 			wantCode:      nil,
 			wantMessage:   "",
-			wantDebugs:    nil,
 			wantStackLine: 0,
 			wantError:     "",
 		},
@@ -85,7 +79,6 @@ func TestFailure(t *testing.T) {
 			shouldNil:     false,
 			wantCode:      TestCodeB,
 			wantMessage:   "aaa",
-			wantDebugs:    nil,
 			wantStackLine: 21,
 			wantError:     "failure_test.TestFailure: aaa: code(1): yyy",
 		},
@@ -95,7 +88,6 @@ func TestFailure(t *testing.T) {
 			shouldNil:     true,
 			wantCode:      nil,
 			wantMessage:   "",
-			wantDebugs:    nil,
 			wantStackLine: 0,
 			wantError:     "",
 		},
@@ -105,7 +97,6 @@ func TestFailure(t *testing.T) {
 			shouldNil:     false,
 			wantCode:      nil,
 			wantMessage:   "",
-			wantDebugs:    nil,
 			wantStackLine: 0,
 			wantError:     io.EOF.Error(),
 		},
@@ -126,8 +117,6 @@ func TestFailure(t *testing.T) {
 			msg, ok := failure.MessageOf(test.err)
 			assert.Equal(t, test.wantMessage != "", ok)
 			assert.Equal(t, test.wantMessage, msg)
-
-			assert.Equal(t, test.wantDebugs, failure.DebugsOf(test.err))
 
 			if test.wantError != "" {
 				assert.EqualError(t, test.err, test.wantError)
@@ -153,24 +142,24 @@ func TestFailure(t *testing.T) {
 
 func TestFailure_Format(t *testing.T) {
 	e1 := fmt.Errorf("yyy")
-	e2 := failure.Translate(e1, TestCodeA, failure.Message("xxx"), failure.Debug{"zzz": "true"})
+	e2 := failure.Translate(e1, TestCodeA, failure.Message("xxx"), failure.MessageKV{"zzz": "true"})
 	err := failure.Wrap(e2)
 
-	want := "failure_test.TestFailure_Format: failure_test.TestFailure_Format: xxx: code(code_a): yyy"
+	want := "failure_test.TestFailure_Format: failure_test.TestFailure_Format: xxx: zzz=true: code(code_a): yyy"
 	assert.Equal(t, want, fmt.Sprintf("%s", err))
 	assert.Equal(t, want, fmt.Sprintf("%v", err))
 
 	exp := `failure.formatter{error:failure.withCallStack{.*`
 	assert.Regexp(t, exp, fmt.Sprintf("%#v", err))
 
-	exp = `\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:157
-\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:156
+	exp = `\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:146
+\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:145
     message\("xxx"\)
     zzz = true
     code\(code_a\)
     \*errors.errorString\("yyy"\)
 \[CallStack\]
-    \[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:156
+    \[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:145
     \[.*`
 	assert.Regexp(t, exp, fmt.Sprintf("%+v", err))
 }

--- a/wrapper.go
+++ b/wrapper.go
@@ -128,6 +128,7 @@ func DebugsOf(err error) []Debug {
 
 // WithCallStackSkip appends call stack to an error
 // skipping top N of frames.
+// You don't have to use this directly, unless using function Custom.
 func WithCallStackSkip(skip int) Wrapper {
 	cs := Callers(skip + 1)
 	return WrapperFunc(func(err error) error {
@@ -193,6 +194,8 @@ func CallStackOf(err error) (CallStack, bool) {
 //     %v+: Print trace for each place, and deepest call stack.
 //     %#v: Print raw structure of the error.
 //     others (%s, %v): Same as err.Error().
+//
+// You don't have to use this directly, unless using function Custom.
 func WithFormatter() Wrapper {
 	return WrapperFunc(func(err error) error {
 		return formatter{err}

--- a/wrapper.go
+++ b/wrapper.go
@@ -51,7 +51,7 @@ type withMessage struct {
 }
 
 func (w withMessage) Error() string {
-	return fmt.Sprintf("%s: %s", w.message, w.underlying.Error())
+	return fmt.Sprintf("%s: %s", w.message, w.underlying)
 }
 
 func (w withMessage) UnwrapError() error {
@@ -111,7 +111,7 @@ type withMessageKV struct {
 }
 
 func (m withMessageKV) Error() string {
-	return fmt.Sprintf("%s: %s", m.memo, m.underlying.Error())
+	return fmt.Sprintf("%s: %s", m.memo, m.underlying)
 }
 
 func (m withMessageKV) UnwrapError() error {
@@ -129,24 +129,24 @@ func WithCallStackSkip(skip int) Wrapper {
 	cs := Callers(skip + 1)
 	return WrapperFunc(func(err error) error {
 		return withCallStack{
-			err,
 			cs,
+			err,
 		}
 	})
 }
 
 type withCallStack struct {
-	err       error
-	callStack CallStack
+	callStack  CallStack
+	underlying error
 }
 
 func (w withCallStack) Error() string {
 	head := w.callStack.HeadFrame()
-	return fmt.Sprintf("%s.%s: %s", head.Pkg(), head.Func(), w.err.Error())
+	return fmt.Sprintf("%s.%s: %s", head.Pkg(), head.Func(), w.underlying)
 }
 
 func (w withCallStack) UnwrapError() error {
-	return w.err
+	return w.underlying
 }
 
 func (w withCallStack) GetCallStack() CallStack {

--- a/wrapper.go
+++ b/wrapper.go
@@ -3,6 +3,7 @@ package failure
 import (
 	"bytes"
 	"fmt"
+	"sort"
 
 	"io"
 
@@ -94,8 +95,15 @@ type MessageKV map[string]string
 
 // WrapError implements the Wrapper interface.
 func (m MessageKV) WrapError(err error) error {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+
 	buf := &bytes.Buffer{}
-	for k, v := range m {
+	for _, k := range keys {
+		v := m[k]
 		if buf.Len() != 0 {
 			buf.WriteRune(' ')
 		}

--- a/wrapper.go
+++ b/wrapper.go
@@ -33,17 +33,28 @@ func (f WrapperFunc) WrapError(err error) error {
 // Message appends error message to an error.
 func Message(msg string) Wrapper {
 	return WrapperFunc(func(err error) error {
-		return withMessage{err, msg}
+		return withMessage{msg, err}
+	})
+}
+
+// Messagef appends formatted error message to an error.
+func Messagef(format string, args ...interface{}) Wrapper {
+	return WrapperFunc(func(err error) error {
+		return withMessage{fmt.Sprintf(format, args...), err}
 	})
 }
 
 type withMessage struct {
-	error
-	message string
+	message    string
+	underlying error
+}
+
+func (w withMessage) Error() string {
+	return fmt.Sprintf("%s: %s", w.message, w.underlying.Error())
 }
 
 func (w withMessage) UnwrapError() error {
-	return w.error
+	return w.underlying
 }
 
 func (w withMessage) GetMessage() string {


### PR DESCRIPTION
# Changes

- Print message in `err.Error()`
- Add `Messagef`
- Reverse wrapping order in `Custom`
- Change `Failure` form struct to interface
- Add `WithCode`, `NewFailure`
- Rename `Debug` to `MessageKV` and print values in `err.Error()`
- Remove `DebugsOf`
- Add `Unexpected`

# Motivation

- Users expect that the message is also printed in `err.Error()`
- `failure.Wrap(err, failure.Message("a"), failure.Message("b")` should be `a: b: error` instead of `b: a: error`
- Users don't have to know about an actual struct `Failure`. Use interface.
- No use case found for `DebugsOf`
- `Unexpected` for error without error code (for internal error, because expected errors should have an error code)