### PR TITLE
Remove GetMessage method from unexpected error

### DIFF
--- a/failure.go
+++ b/failure.go
@@ -67,10 +67,6 @@ func (e unexpected) Error() string {
 	return string(e)
 }
 
-func (e unexpected) GetMessage() string {
-	return string(e)
-}
-
 // Unexpected creates an error from message without error code.
 // The returned error should be kind of internal or unknown error.
 func Unexpected(msg string, wrappers ...Wrapper) error {

--- a/failure_test.go
+++ b/failure_test.go
@@ -105,7 +105,7 @@ func TestFailure(t *testing.T) {
 
 			shouldNil:     false,
 			wantCode:      nil,
-			wantMessage:   "unexpected error",
+			wantMessage:   "",
 			wantStackLine: 104,
 			wantError:     "failure_test.TestFailure: aaa=1: unexpected error",
 		},


### PR DESCRIPTION
# Changes

Remove GetMessage method from unexpected error.

# Motivation

Unexpected errors should be unexpected, so we cannot make an appropriate message.
Since it might expose an internal implementation, it should not be extracted by `MessageOf` function.