### PR TITLE
Remove dependencies on external libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,5 @@ cover:
 view-cover: cover
 	GO111MODULE=on go tool cover -html coverage.txt
 
+mod:
+	GO111MODULE=on go mod tidy

--- a/callstack.go
+++ b/callstack.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // CallStack represents a call stack.
@@ -90,15 +88,6 @@ func Callers(skip int) CallStack {
 	}
 
 	return callStack{pcs[:n]}
-}
-
-func callStackFromPkgErrors(st errors.StackTrace) CallStack {
-	pcs := make([]uintptr, len(st))
-	for i, v := range st {
-		pcs[i] = uintptr(v)
-	}
-
-	return callStack{[]uintptr(pcs)}
 }
 
 // Frame represents a stack frame.

--- a/callstack_test.go
+++ b/callstack_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/morikuni/failure"
-	"github.com/pkg/errors"
 )
 
 func X() failure.CallStack {
@@ -18,37 +17,13 @@ func TestCallers(t *testing.T) {
 	shouldContain(t, fs[0].Path(), "github.com/morikuni/failure/callstack_test.go")
 	shouldContain(t, fs[0].File(), "callstack_test.go")
 	shouldEqual(t, fs[0].Func(), "X")
-	shouldEqual(t, fs[0].Line(), 12)
+	shouldEqual(t, fs[0].Line(), 11)
 	shouldEqual(t, fs[0].Pkg(), "failure_test")
 
 	shouldContain(t, fs[1].Path(), "github.com/morikuni/failure/callstack_test.go")
 	shouldContain(t, fs[1].File(), "callstack_test.go")
 	shouldEqual(t, fs[1].Func(), "TestCallers")
-	shouldEqual(t, fs[1].Line(), 16)
-	shouldEqual(t, fs[1].Pkg(), "failure_test")
-}
-
-func Y() error {
-	return errors.New("aaa")
-}
-
-func TestCallStackFromPkgErrors(t *testing.T) {
-	err := Y()
-
-	cs, ok := failure.CallStackOf(err)
-	shouldEqual(t, ok, true)
-	fs := cs.Frames()
-
-	shouldContain(t, fs[0].Path(), "github.com/morikuni/failure/callstack_test.go")
-	shouldContain(t, fs[0].File(), "callstack_test.go")
-	shouldEqual(t, fs[0].Func(), "Y")
-	shouldEqual(t, fs[0].Line(), 32)
-	shouldEqual(t, fs[0].Pkg(), "failure_test")
-
-	shouldContain(t, fs[1].Path(), "github.com/morikuni/failure/callstack_test.go")
-	shouldContain(t, fs[1].File(), "callstack_test.go")
-	shouldEqual(t, fs[1].Func(), "TestCallStackFromPkgErrors")
-	shouldEqual(t, fs[1].Line(), 36)
+	shouldEqual(t, fs[1].Line(), 15)
 	shouldEqual(t, fs[1].Pkg(), "failure_test")
 }
 
@@ -65,12 +40,12 @@ func TestCallStack_Format(t *testing.T) {
 	)
 	shouldMatch(t,
 		fmt.Sprintf("%#v", cs),
-		`\[\]failure.Frame{/.+/github.com/morikuni/failure/callstack_test.go:12, /.+/github.com/morikuni/failure/callstack_test.go:56, .*}`,
+		`\[\]failure.Frame{/.+/github.com/morikuni/failure/callstack_test.go:11, /.+/github.com/morikuni/failure/callstack_test.go:31, .*}`,
 	)
 	shouldMatch(t,
 		fmt.Sprintf("%+v", cs),
-		`\[failure_test.X\] /.+/github.com/morikuni/failure/callstack_test.go:12
-\[failure_test.TestCallStack_Format\] /.+/github.com/morikuni/failure/callstack_test.go:56
+		`\[failure_test.X\] /.+/github.com/morikuni/failure/callstack_test.go:11
+\[failure_test.TestCallStack_Format\] /.+/github.com/morikuni/failure/callstack_test.go:31
 \[.*`,
 	)
 }
@@ -80,19 +55,19 @@ func TestFrame_Format(t *testing.T) {
 
 	shouldMatch(t,
 		fmt.Sprintf("%v", f),
-		`/.+/github.com/morikuni/failure/callstack_test.go:12`,
+		`/.+/github.com/morikuni/failure/callstack_test.go:11`,
 	)
 	shouldMatch(t,
 		fmt.Sprintf("%s", f),
-		`/.+/github.com/morikuni/failure/callstack_test.go:12`,
+		`/.+/github.com/morikuni/failure/callstack_test.go:11`,
 	)
 	shouldMatch(t,
 		fmt.Sprintf("%#v", f),
-		`/.+/github.com/morikuni/failure/callstack_test.go:12`,
+		`/.+/github.com/morikuni/failure/callstack_test.go:11`,
 	)
 	shouldMatch(t,
 		fmt.Sprintf("%+v", f),
-		`\[failure_test.X\] /.+/github.com/morikuni/failure/callstack_test.go:12`,
+		`\[failure_test.X\] /.+/github.com/morikuni/failure/callstack_test.go:11`,
 	)
 }
 
@@ -102,10 +77,10 @@ func TestCallStack_Frames(t *testing.T) {
 
 	shouldEqual(t, cs.Frames(), fs)
 
-	shouldEqual(t, fs[0].Line(), 12)
+	shouldEqual(t, fs[0].Line(), 11)
 	shouldEqual(t, fs[0].Func(), "X")
 
-	shouldEqual(t, fs[1].Line(), 100)
+	shouldEqual(t, fs[1].Line(), 75)
 	shouldEqual(t, fs[1].Func(), "TestCallStack_Frames")
 }
 
@@ -119,7 +94,7 @@ func TestFrame(t *testing.T) {
 	f := X().HeadFrame()
 
 	shouldEqual(t, f.Func(), "X")
-	shouldEqual(t, f.Line(), 12)
+	shouldEqual(t, f.Line(), 11)
 	shouldEqual(t, f.File(), "callstack_test.go")
 	shouldContain(t, f.Path(), "github.com/morikuni/failure/callstack_test.go")
 	shouldEqual(t, f.Pkg(), "failure_test")

--- a/callstack_test.go
+++ b/callstack_test.go
@@ -102,11 +102,11 @@ func TestCallStack_Frames(t *testing.T) {
 
 	shouldEqual(t, cs.Frames(), fs)
 
-	shouldEqual(t, 12, fs[0].Line())
-	shouldEqual(t, "X", fs[0].Func())
+	shouldEqual(t, fs[0].Line(), 12)
+	shouldEqual(t, fs[0].Func(), "X")
 
-	shouldEqual(t, 100, fs[1].Line())
-	shouldEqual(t, "TestCallStack_Frames", fs[1].Func())
+	shouldEqual(t, fs[1].Line(), 100)
+	shouldEqual(t, fs[1].Func(), "TestCallStack_Frames")
 }
 
 func TestCallStack_HeadFrame(t *testing.T) {
@@ -118,9 +118,9 @@ func TestCallStack_HeadFrame(t *testing.T) {
 func TestFrame(t *testing.T) {
 	f := X().HeadFrame()
 
-	shouldEqual(t, "X", f.Func())
-	shouldEqual(t, 12, f.Line())
-	shouldEqual(t, "callstack_test.go", f.File())
+	shouldEqual(t, f.Func(), "X")
+	shouldEqual(t, f.Line(), 12)
+	shouldEqual(t, f.File(), "callstack_test.go")
 	shouldContain(t, f.Path(), "github.com/morikuni/failure/callstack_test.go")
-	shouldEqual(t, "failure_test", f.Pkg())
+	shouldEqual(t, f.Pkg(), "failure_test")
 }

--- a/callstack_test.go
+++ b/callstack_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/morikuni/failure"
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
 )
 
 func X() failure.CallStack {
@@ -16,17 +15,17 @@ func X() failure.CallStack {
 func TestCallers(t *testing.T) {
 	fs := X().Frames()
 
-	assert.Contains(t, fs[0].Path(), "github.com/morikuni/failure/callstack_test.go")
-	assert.Contains(t, fs[0].File(), "callstack_test.go")
-	assert.Equal(t, fs[0].Func(), "X")
-	assert.Equal(t, fs[0].Line(), 13)
-	assert.Equal(t, fs[0].Pkg(), "failure_test")
+	shouldContain(t, fs[0].Path(), "github.com/morikuni/failure/callstack_test.go")
+	shouldContain(t, fs[0].File(), "callstack_test.go")
+	shouldEqual(t, fs[0].Func(), "X")
+	shouldEqual(t, fs[0].Line(), 12)
+	shouldEqual(t, fs[0].Pkg(), "failure_test")
 
-	assert.Contains(t, fs[1].Path(), "github.com/morikuni/failure/callstack_test.go")
-	assert.Contains(t, fs[1].File(), "callstack_test.go")
-	assert.Equal(t, fs[1].Func(), "TestCallers")
-	assert.Equal(t, fs[1].Line(), 17)
-	assert.Equal(t, fs[1].Pkg(), "failure_test")
+	shouldContain(t, fs[1].Path(), "github.com/morikuni/failure/callstack_test.go")
+	shouldContain(t, fs[1].File(), "callstack_test.go")
+	shouldEqual(t, fs[1].Func(), "TestCallers")
+	shouldEqual(t, fs[1].Line(), 16)
+	shouldEqual(t, fs[1].Pkg(), "failure_test")
 }
 
 func Y() error {
@@ -37,63 +36,63 @@ func TestCallStackFromPkgErrors(t *testing.T) {
 	err := Y()
 
 	cs, ok := failure.CallStackOf(err)
-	assert.True(t, ok)
+	shouldEqual(t, ok, true)
 	fs := cs.Frames()
 
-	assert.Contains(t, fs[0].Path(), "github.com/morikuni/failure/callstack_test.go")
-	assert.Contains(t, fs[0].File(), "callstack_test.go")
-	assert.Equal(t, fs[0].Func(), "Y")
-	assert.Equal(t, fs[0].Line(), 33)
-	assert.Equal(t, fs[0].Pkg(), "failure_test")
+	shouldContain(t, fs[0].Path(), "github.com/morikuni/failure/callstack_test.go")
+	shouldContain(t, fs[0].File(), "callstack_test.go")
+	shouldEqual(t, fs[0].Func(), "Y")
+	shouldEqual(t, fs[0].Line(), 32)
+	shouldEqual(t, fs[0].Pkg(), "failure_test")
 
-	assert.Contains(t, fs[1].Path(), "github.com/morikuni/failure/callstack_test.go")
-	assert.Contains(t, fs[1].File(), "callstack_test.go")
-	assert.Equal(t, fs[1].Func(), "TestCallStackFromPkgErrors")
-	assert.Equal(t, fs[1].Line(), 37)
-	assert.Equal(t, fs[1].Pkg(), "failure_test")
+	shouldContain(t, fs[1].Path(), "github.com/morikuni/failure/callstack_test.go")
+	shouldContain(t, fs[1].File(), "callstack_test.go")
+	shouldEqual(t, fs[1].Func(), "TestCallStackFromPkgErrors")
+	shouldEqual(t, fs[1].Line(), 36)
+	shouldEqual(t, fs[1].Pkg(), "failure_test")
 }
 
 func TestCallStack_Format(t *testing.T) {
 	cs := X()
 
-	assert.Regexp(t,
-		`failure_test.X: failure_test.TestCallStack_Format: .*`,
+	shouldMatch(t,
 		fmt.Sprintf("%v", cs),
-	)
-	assert.Regexp(t,
 		`failure_test.X: failure_test.TestCallStack_Format: .*`,
+	)
+	shouldMatch(t,
 		fmt.Sprintf("%s", cs),
+		`failure_test.X: failure_test.TestCallStack_Format: .*`,
 	)
-	assert.Regexp(t,
-		`\[\]failure.Frame{/.+/github.com/morikuni/failure/callstack_test.go:13, /.+/github.com/morikuni/failure/callstack_test.go:57, .*}`,
+	shouldMatch(t,
 		fmt.Sprintf("%#v", cs),
+		`\[\]failure.Frame{/.+/github.com/morikuni/failure/callstack_test.go:12, /.+/github.com/morikuni/failure/callstack_test.go:56, .*}`,
 	)
-	assert.Regexp(t,
-		`\[failure_test.X\] /.+/github.com/morikuni/failure/callstack_test.go:13
-\[failure_test.TestCallStack_Format\] /.+/github.com/morikuni/failure/callstack_test.go:57
-\[.*`,
+	shouldMatch(t,
 		fmt.Sprintf("%+v", cs),
+		`\[failure_test.X\] /.+/github.com/morikuni/failure/callstack_test.go:12
+\[failure_test.TestCallStack_Format\] /.+/github.com/morikuni/failure/callstack_test.go:56
+\[.*`,
 	)
 }
 
 func TestFrame_Format(t *testing.T) {
 	f := X().HeadFrame()
 
-	assert.Regexp(t,
-		`/.+/github.com/morikuni/failure/callstack_test.go:13`,
+	shouldMatch(t,
 		fmt.Sprintf("%v", f),
+		`/.+/github.com/morikuni/failure/callstack_test.go:12`,
 	)
-	assert.Regexp(t,
-		`/.+/github.com/morikuni/failure/callstack_test.go:13`,
+	shouldMatch(t,
 		fmt.Sprintf("%s", f),
+		`/.+/github.com/morikuni/failure/callstack_test.go:12`,
 	)
-	assert.Regexp(t,
-		`/.+/github.com/morikuni/failure/callstack_test.go:13`,
+	shouldMatch(t,
 		fmt.Sprintf("%#v", f),
+		`/.+/github.com/morikuni/failure/callstack_test.go:12`,
 	)
-	assert.Regexp(t,
-		`\[failure_test.X\] /.+/github.com/morikuni/failure/callstack_test.go:13`,
+	shouldMatch(t,
 		fmt.Sprintf("%+v", f),
+		`\[failure_test.X\] /.+/github.com/morikuni/failure/callstack_test.go:12`,
 	)
 }
 
@@ -101,27 +100,27 @@ func TestCallStack_Frames(t *testing.T) {
 	cs := X()
 	fs := cs.Frames()
 
-	assert.Equal(t, cs.Frames(), fs)
+	shouldEqual(t, cs.Frames(), fs)
 
-	assert.Equal(t, 13, fs[0].Line())
-	assert.Equal(t, "X", fs[0].Func())
+	shouldEqual(t, 12, fs[0].Line())
+	shouldEqual(t, "X", fs[0].Func())
 
-	assert.Equal(t, 101, fs[1].Line())
-	assert.Equal(t, "TestCallStack_Frames", fs[1].Func())
+	shouldEqual(t, 100, fs[1].Line())
+	shouldEqual(t, "TestCallStack_Frames", fs[1].Func())
 }
 
 func TestCallStack_HeadFrame(t *testing.T) {
 	cs := X()
 
-	assert.Equal(t, cs.Frames()[0], cs.HeadFrame())
+	shouldEqual(t, cs.Frames()[0], cs.HeadFrame())
 }
 
 func TestFrame(t *testing.T) {
 	f := X().HeadFrame()
 
-	assert.Equal(t, "X", f.Func())
-	assert.Equal(t, 13, f.Line())
-	assert.Equal(t, "callstack_test.go", f.File())
-	assert.Contains(t, f.Path(), "github.com/morikuni/failure/callstack_test.go")
-	assert.Equal(t, "failure_test", f.Pkg())
+	shouldEqual(t, "X", f.Func())
+	shouldEqual(t, 12, f.Line())
+	shouldEqual(t, "callstack_test.go", f.File())
+	shouldContain(t, f.Path(), "github.com/morikuni/failure/callstack_test.go")
+	shouldEqual(t, "failure_test", f.Pkg())
 }

--- a/code_test.go
+++ b/code_test.go
@@ -26,9 +26,9 @@ func TestCode(t *testing.T) {
 		c2 CustomCode         = "123"
 	)
 
-	shouldEqual(t, "123", s.ErrorCode())
-	shouldEqual(t, "123", i.ErrorCode())
-	shouldEqual(t, "123", c.ErrorCode())
+	shouldEqual(t, s.ErrorCode(), "123")
+	shouldEqual(t, i.ErrorCode(), "123")
+	shouldEqual(t, c.ErrorCode(), "123")
 
 	shouldEqual(t, s, s2)
 	shouldEqual(t, i, i2)

--- a/code_test.go
+++ b/code_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 
 	"github.com/morikuni/failure"
-	"github.com/stretchr/testify/assert"
 )
 
 type CustomCode string
@@ -27,17 +26,17 @@ func TestCode(t *testing.T) {
 		c2 CustomCode         = "123"
 	)
 
-	assert.Equal(t, "123", s.ErrorCode())
-	assert.Equal(t, "123", i.ErrorCode())
-	assert.Equal(t, "123", c.ErrorCode())
+	shouldEqual(t, "123", s.ErrorCode())
+	shouldEqual(t, "123", i.ErrorCode())
+	shouldEqual(t, "123", c.ErrorCode())
 
-	assert.Equal(t, s, s2)
-	assert.Equal(t, i, i2)
-	assert.Equal(t, c, c2)
+	shouldEqual(t, s, s2)
+	shouldEqual(t, i, i2)
+	shouldEqual(t, c, c2)
 
-	assert.NotEqual(t, s, i)
-	assert.NotEqual(t, s, c)
-	assert.NotEqual(t, i, c)
+	shouldDiffer(t, s, i)
+	shouldDiffer(t, s, c)
+	shouldDiffer(t, i, c)
 }
 
 func TestIs(t *testing.T) {
@@ -50,22 +49,22 @@ func TestIs(t *testing.T) {
 	errB := failure.Translate(errA, B)
 	errC := failure.Wrap(errB)
 
-	assert.True(t, failure.Is(errA, A))
-	assert.True(t, failure.Is(errB, B))
-	assert.True(t, failure.Is(errC, B))
+	shouldEqual(t, failure.Is(errA, A), true)
+	shouldEqual(t, failure.Is(errB, B), true)
+	shouldEqual(t, failure.Is(errC, B), true)
 
-	assert.True(t, failure.Is(errA, A, B))
-	assert.True(t, failure.Is(errB, A, B))
-	assert.True(t, failure.Is(errC, A, B))
+	shouldEqual(t, failure.Is(errA, A, B), true)
+	shouldEqual(t, failure.Is(errB, A, B), true)
+	shouldEqual(t, failure.Is(errC, A, B), true)
 
-	assert.False(t, failure.Is(errA, B))
-	assert.False(t, failure.Is(errB, A))
-	assert.False(t, failure.Is(errC, A))
+	shouldEqual(t, failure.Is(errA, B), false)
+	shouldEqual(t, failure.Is(errB, A), false)
+	shouldEqual(t, failure.Is(errC, A), false)
 
-	assert.False(t, failure.Is(nil, A, B))
-	assert.False(t, failure.Is(io.EOF, A, B))
-	assert.False(t, failure.Is(errA))
+	shouldEqual(t, failure.Is(nil, A, B), false)
+	shouldEqual(t, failure.Is(io.EOF, A, B), false)
+	shouldEqual(t, failure.Is(errA), false)
 
-	assert.True(t, failure.Is(nil, nil))
-	assert.True(t, failure.Is(errors.New("error"), nil))
+	shouldEqual(t, failure.Is(nil, nil), true)
+	shouldEqual(t, failure.Is(errors.New("error"), nil), true)
 }

--- a/failure_test.go
+++ b/failure_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/morikuni/failure"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -16,7 +15,6 @@ const (
 
 func TestFailure(t *testing.T) {
 	base := failure.New(TestCodeA, failure.Message("xxx"), failure.MessageKV{"zzz": "true"})
-	pkgErr := errors.New("yyy")
 	tests := map[string]struct {
 		err error
 
@@ -32,7 +30,7 @@ func TestFailure(t *testing.T) {
 			shouldNil:     false,
 			wantCode:      TestCodeA,
 			wantMessage:   "",
-			wantStackLine: 30,
+			wantStackLine: 28,
 			wantError:     "failure_test.TestFailure: aaa=1: code(code_a)",
 		},
 		"translate": {
@@ -41,7 +39,7 @@ func TestFailure(t *testing.T) {
 			shouldNil:     false,
 			wantCode:      TestCodeB,
 			wantMessage:   "xxx",
-			wantStackLine: 18,
+			wantStackLine: 17,
 			wantError:     "failure_test.TestFailure: code(1): failure_test.TestFailure: xxx: zzz=true: code(code_a)",
 		},
 		"overwrite": {
@@ -50,7 +48,7 @@ func TestFailure(t *testing.T) {
 			shouldNil:     false,
 			wantCode:      TestCodeB,
 			wantMessage:   "aaa: bbb",
-			wantStackLine: 18,
+			wantStackLine: 17,
 			wantError:     "failure_test.TestFailure: aaa: bbb: ccc=1 ddd=2: code(1): failure_test.TestFailure: xxx: zzz=true: code(code_a)",
 		},
 		"wrap": {
@@ -59,7 +57,7 @@ func TestFailure(t *testing.T) {
 			shouldNil:     false,
 			wantCode:      nil,
 			wantMessage:   "",
-			wantStackLine: 57,
+			wantStackLine: 55,
 			wantError:     "failure_test.TestFailure: " + io.EOF.Error(),
 		},
 		"wrap nil": {
@@ -70,15 +68,6 @@ func TestFailure(t *testing.T) {
 			wantMessage:   "",
 			wantStackLine: 0,
 			wantError:     "",
-		},
-		"pkg/errors": {
-			err: failure.Translate(pkgErr, TestCodeB, failure.Message("aaa")),
-
-			shouldNil:     false,
-			wantCode:      TestCodeB,
-			wantMessage:   "aaa",
-			wantStackLine: 19,
-			wantError:     "failure_test.TestFailure: aaa: code(1): yyy",
 		},
 		"nil": {
 			err: nil,
@@ -104,7 +93,7 @@ func TestFailure(t *testing.T) {
 			shouldNil:     false,
 			wantCode:      nil,
 			wantMessage:   "",
-			wantStackLine: 102,
+			wantStackLine: 91,
 			wantError:     "failure_test.TestFailure: aaa=1: unexpected error",
 		},
 	}
@@ -157,14 +146,14 @@ func TestFailure_Format(t *testing.T) {
 	exp := `&failure.formatter{error:\(\*failure.withCallStack\)\(.*`
 	shouldMatch(t, fmt.Sprintf("%#v", err), exp)
 
-	exp = `\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:151
-\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:150
+	exp = `\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:140
+\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:139
     message\("xxx"\)
     zzz = true
     code\(code_a\)
     \*errors.errorString\("yyy"\)
 \[CallStack\]
-    \[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:150
+    \[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:139
     \[.*`
 	shouldMatch(t, fmt.Sprintf("%+v", err), exp)
 }

--- a/failure_test.go
+++ b/failure_test.go
@@ -118,12 +118,12 @@ func TestFailure(t *testing.T) {
 			}
 
 			code, ok := failure.CodeOf(test.err)
-			shouldEqual(t, test.wantCode != nil, ok)
-			shouldEqual(t, test.wantCode, code)
+			shouldEqual(t, ok, test.wantCode != nil)
+			shouldEqual(t, code, test.wantCode)
 
 			msg, ok := failure.MessageOf(test.err)
-			shouldEqual(t, test.wantMessage != "", ok)
-			shouldEqual(t, test.wantMessage, msg)
+			shouldEqual(t, ok, test.wantMessage != "")
+			shouldEqual(t, msg, test.wantMessage)
 
 			if test.wantError != "" {
 				shouldEqual(t, test.err.Error(), test.wantError)
@@ -136,7 +136,7 @@ func TestFailure(t *testing.T) {
 				shouldEqual(t, ok, true)
 				fs := cs.Frames()
 				shouldDiffer(t, len(fs), 0)
-				shouldEqual(t, test.wantStackLine, fs[0].Line())
+				shouldEqual(t, fs[0].Line(), test.wantStackLine)
 			} else {
 				shouldEqual(t, ok, false)
 				shouldEqual(t, cs, nil)
@@ -151,8 +151,8 @@ func TestFailure_Format(t *testing.T) {
 	err := failure.Wrap(e2)
 
 	want := "failure_test.TestFailure_Format: failure_test.TestFailure_Format: xxx: zzz=true: code(code_a): yyy"
-	shouldEqual(t, want, fmt.Sprintf("%s", err))
-	shouldEqual(t, want, fmt.Sprintf("%v", err))
+	shouldEqual(t, fmt.Sprintf("%s", err), want)
+	shouldEqual(t, fmt.Sprintf("%v", err), want)
 
 	exp := `&failure.formatter{error:\(\*failure.withCallStack\)\(.*`
 	shouldMatch(t, fmt.Sprintf("%#v", err), exp)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/morikuni/failure
 
-require github.com/pkg/errors v0.8.0
+go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,3 @@
 module github.com/morikuni/failure
 
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pkg/errors v0.8.0
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.2.2
-)
+require github.com/pkg/errors v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
-github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,2 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -2,11 +2,11 @@ package failure_test
 
 import (
 	"io"
+	"reflect"
 	"testing"
 
 	"github.com/morikuni/failure"
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
 )
 
 type a struct {
@@ -33,18 +33,18 @@ func TestIterator(t *testing.T) {
 	var c int
 	for i.Next() {
 		err := i.Error()
-		assert.IsType(t, wantTypes[c], err)
+		shouldEqual(t, reflect.TypeOf(wantTypes[c]), reflect.TypeOf(err))
 		c++
 	}
 }
 
 func TestCauseOf(t *testing.T) {
 	f := failure.Wrap(io.EOF)
-	assert.Equal(t, io.EOF, failure.CauseOf(f))
+	shouldEqual(t, io.EOF, failure.CauseOf(f))
 
 	base := failure.Wrap(io.EOF)
 	pkgErr := errors.Wrap(base, "aaa")
-	assert.Equal(t, io.EOF, failure.CauseOf(failure.Wrap(pkgErr)))
+	shouldEqual(t, io.EOF, failure.CauseOf(failure.Wrap(pkgErr)))
 
-	assert.Nil(t, failure.CauseOf(nil))
+	shouldEqual(t, failure.CauseOf(nil), nil)
 }

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -33,18 +33,18 @@ func TestIterator(t *testing.T) {
 	var c int
 	for i.Next() {
 		err := i.Error()
-		shouldEqual(t, reflect.TypeOf(wantTypes[c]), reflect.TypeOf(err))
+		shouldEqual(t, reflect.TypeOf(err), reflect.TypeOf(wantTypes[c]))
 		c++
 	}
 }
 
 func TestCauseOf(t *testing.T) {
 	f := failure.Wrap(io.EOF)
-	shouldEqual(t, io.EOF, failure.CauseOf(f))
+	shouldEqual(t, failure.CauseOf(f), io.EOF)
 
 	base := failure.Wrap(io.EOF)
 	pkgErr := errors.Wrap(base, "aaa")
-	shouldEqual(t, io.EOF, failure.CauseOf(failure.Wrap(pkgErr)))
+	shouldEqual(t, failure.CauseOf(failure.Wrap(pkgErr)), io.EOF)
 
 	shouldEqual(t, failure.CauseOf(nil), nil)
 }

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -1,0 +1,37 @@
+package failure_test
+
+import (
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func shouldContain(t *testing.T, s, sub string) {
+	t.Helper()
+	if !strings.Contains(s, sub) {
+		t.Errorf("%q does not contain %q", s, sub)
+	}
+}
+
+func shouldMatch(t *testing.T, s, re string) {
+	t.Helper()
+	r := regexp.MustCompile(re)
+	if !r.MatchString(s) {
+		t.Errorf("%q does not match %q", s, re)
+	}
+}
+
+func shouldEqual(t *testing.T, a, b interface{}) {
+	t.Helper()
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("%#v does not equal to %#v", a, b)
+	}
+}
+
+func shouldDiffer(t *testing.T, a, b interface{}) {
+	t.Helper()
+	if reflect.DeepEqual(a, b) {
+		t.Errorf("%#v does not differ from %#v", a, b)
+	}
+}

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -25,13 +25,13 @@ func shouldMatch(t *testing.T, s, re string) {
 func shouldEqual(t *testing.T, a, b interface{}) {
 	t.Helper()
 	if !reflect.DeepEqual(a, b) {
-		t.Errorf("%#v does not equal to %#v", a, b)
+		t.Errorf("%T(%#v) does not equal to %T(%#v)", a, a, b, b)
 	}
 }
 
 func shouldDiffer(t *testing.T, a, b interface{}) {
 	t.Helper()
 	if reflect.DeepEqual(a, b) {
-		t.Errorf("%#v does not differ from %#v", a, b)
+		t.Errorf("%T(%#v) does not differ from %T(%#v)", a, a, b, b)
 	}
 }

--- a/wrapper.go
+++ b/wrapper.go
@@ -6,8 +6,6 @@ import (
 	"sort"
 
 	"io"
-
-	"github.com/pkg/errors"
 )
 
 // Unwrapper interface is used by iterator.
@@ -171,19 +169,13 @@ func CallStackOf(err error) (CallStack, bool) {
 	type callStackGetter interface {
 		GetCallStack() CallStack
 	}
-	type stackTracer interface {
-		StackTrace() errors.StackTrace
-	}
 
 	var last CallStack
 	i := NewIterator(err)
 	for i.Next() {
 		err := i.Error()
-		switch t := err.(type) {
-		case callStackGetter:
-			last = t.GetCallStack()
-		case stackTracer:
-			last = callStackFromPkgErrors(t.StackTrace())
+		if g, ok := err.(callStackGetter); ok {
+			last = g.GetCallStack()
 		}
 	}
 


### PR DESCRIPTION
# Changes

Remove dependencies on external libraries.

Remove support for extracting callstack from pkg/errors, but still supporting unwrapping from pkg/errors.


# Motivation

Less dependency is better, especially for libraries.
Users don't have to introduce an unexpected dependency.