### PR TITLE
Remove IntCode type

### DIFF
--- a/code.go
+++ b/code.go
@@ -22,7 +22,9 @@ func Is(err error, codes ...Code) bool {
 
 // Code represents an error code of the error.
 // The code should be able to be compared by == operator.
-// You can define your own code type instead of using StringCode type,
+// Basically, it should to be defined as constants.
+//
+// You can also define your own code type instead of using StringCode type,
 // when you want to distinguish errors by type for some purpose (e.g. define
 // code type for each package like user, item, auth etc).
 type Code interface {

--- a/code.go
+++ b/code.go
@@ -1,7 +1,5 @@
 package failure
 
-import "strconv"
-
 // Is checks whether err represents any of given code.
 func Is(err error, codes ...Code) bool {
 	if len(codes) == 0 {
@@ -24,6 +22,9 @@ func Is(err error, codes ...Code) bool {
 
 // Code represents an error code of the error.
 // The code should be able to be compared by == operator.
+// You can define your own code type instead of using StringCode type,
+// when you want to distinguish errors by type for some purpose (e.g. define
+// code type for each package like user, item, auth etc).
 type Code interface {
 	// ErrorCode returns an error code in string representation.
 	ErrorCode() string
@@ -35,12 +36,4 @@ type StringCode string
 // ErrorCode implements the Code interface.
 func (c StringCode) ErrorCode() string {
 	return string(c)
-}
-
-// IntCode represents an error code in int64.
-type IntCode int64
-
-// ErrorCode implements the Code interface.
-func (c IntCode) ErrorCode() string {
-	return strconv.FormatInt(int64(c), 10)
 }

--- a/code_test.go
+++ b/code_test.go
@@ -18,25 +18,19 @@ func (c CustomCode) ErrorCode() string {
 func TestCode(t *testing.T) {
 	const (
 		s failure.StringCode = "123"
-		i failure.IntCode    = 123
 		c CustomCode         = "123"
 
 		s2 failure.StringCode = "123"
-		i2 failure.IntCode    = 123
 		c2 CustomCode         = "123"
 	)
 
 	shouldEqual(t, s.ErrorCode(), "123")
-	shouldEqual(t, i.ErrorCode(), "123")
 	shouldEqual(t, c.ErrorCode(), "123")
 
 	shouldEqual(t, s, s2)
-	shouldEqual(t, i, i2)
 	shouldEqual(t, c, c2)
 
-	shouldDiffer(t, s, i)
 	shouldDiffer(t, s, c)
-	shouldDiffer(t, i, c)
 }
 
 func TestIs(t *testing.T) {

--- a/failure_test.go
+++ b/failure_test.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	TestCodeA failure.StringCode = "code_a"
-	TestCodeB failure.IntCode    = 1
+	TestCodeB failure.StringCode = "1"
 )
 
 func TestFailure(t *testing.T) {

--- a/iterator.go
+++ b/iterator.go
@@ -12,7 +12,8 @@ type Iterator struct {
 }
 
 // Next try to unwrap an error and returns whether the next
-// error is present.
+// error is present. Since this method updates internal state of the
+// iterator, should be called only once per iteration.
 func (i *Iterator) Next() bool {
 	i.err = i.unwrapError()
 	if i.err == nil {


### PR DESCRIPTION
# Changes

Remove `IntCode` type.

# Motivation

I think no-one uses it.
We are still providing `StringCode` for the usual purpose.