### PR TITLE
Rename MessageKV to Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ for i.Next() { // unwrap error
 
 ## Example
 
-### You can try it on [The Go Playground](https://play.golang.org/p/-t_jA32oBWa)
+### You can try it on [The Go Playground](https://play.golang.org/p/Pmgm7-7J1_c)
 
 You can also see the example on GitHub by opening this.
 
@@ -76,7 +76,7 @@ func GetACL(projectID, userID string) (acl interface{}, e error) {
 	notFound := true
 	if notFound {
 		return nil, failure.New(NotFound,
-			failure.MessageKV{"project_id": projectID, "user_id": userID},
+			failure.Context{"project_id": projectID, "user_id": userID},
 		)
 	}
 	return nil, failure.Unexpected("unexpected error")
@@ -88,7 +88,7 @@ func GetProject(projectID, userID string) (project interface{}, e error) {
 		if failure.Is(err, NotFound) {
 			return nil, failure.Translate(err, Forbidden,
 				failure.Message("no acl exists"),
-				failure.MessageKV{"additional_info": "hello"},
+				failure.Context{"additional_info": "hello"},
 			)
 		}
 		return nil, failure.Wrap(err)
@@ -146,7 +146,7 @@ func HandleError(w http.ResponseWriter, err error) {
 	fmt.Printf("Cause = %v\n", failure.CauseOf(err))
 
 	fmt.Println()
-	fmt.Println("============ %+v ============")
+	fmt.Println("============ Detail ============")
 	fmt.Printf("%+v\n", err)
 	// [main.GetProject] /go/src/github.com/morikuni/failure/example/main.go:36
 	//     message("no acl exists")

--- a/code.go
+++ b/code.go
@@ -1,6 +1,6 @@
 package failure
 
-// Is checks whether err represents any of given code.
+// Is checks whether an error code from the err is any of given code.
 func Is(err error, codes ...Code) bool {
 	if len(codes) == 0 {
 		return false
@@ -20,7 +20,7 @@ func Is(err error, codes ...Code) bool {
 	return false
 }
 
-// Code represents an error code of the error.
+// Code represents an error code of an error.
 // The code should be able to be compared by == operator.
 // Basically, it should to be defined as constants.
 //

--- a/failure.go
+++ b/failure.go
@@ -12,7 +12,7 @@ type Failure interface {
 	GetCode() Code
 }
 
-// CodeOf extracts an error code from the error.
+// CodeOf extracts an error code from the err.
 func CodeOf(err error) (Code, bool) {
 	if err == nil {
 		return nil, false
@@ -34,7 +34,7 @@ func New(code Code, wrappers ...Wrapper) error {
 	return Custom(Custom(NewFailure(code), wrappers...), WithFormatter(), WithCallStackSkip(1))
 }
 
-// Translate translates err to an error with given code.
+// Translate translates the err to an error with given code.
 // It wraps the error with given wrappers, and automatically
 // add call stack and formatter.
 func Translate(err error, code Code, wrappers ...Wrapper) error {
@@ -75,13 +75,14 @@ func Unexpected(msg string, wrappers ...Wrapper) error {
 
 // NewFailure returns Failure without any wrappers.
 // You don't have to use this directly, unless using function Custom.
-// Probably, you can use New instead of this.
+// Basically, you can use function New instead of this.
 func NewFailure(code Code) Failure {
 	return &withCode{code: code}
 }
 
 // WithCode appends code to an error.
 // You don't have to use this directly, unless using function Custom.
+// Basically, you can use function Translate instead of this.
 func WithCode(code Code) Wrapper {
 	return WrapperFunc(func(err error) error {
 		return &withCode{code, err}

--- a/failure_test.go
+++ b/failure_test.go
@@ -14,7 +14,7 @@ const (
 )
 
 func TestFailure(t *testing.T) {
-	base := failure.New(TestCodeA, failure.Message("xxx"), failure.MessageKV{"zzz": "true"})
+	base := failure.New(TestCodeA, failure.Message("xxx"), failure.Context{"zzz": "true"})
 	tests := map[string]struct {
 		err error
 
@@ -25,7 +25,7 @@ func TestFailure(t *testing.T) {
 		wantError     string
 	}{
 		"new": {
-			err: failure.New(TestCodeA, failure.MessageKV{"aaa": "1"}),
+			err: failure.New(TestCodeA, failure.Context{"aaa": "1"}),
 
 			shouldNil:     false,
 			wantCode:      TestCodeA,
@@ -43,7 +43,7 @@ func TestFailure(t *testing.T) {
 			wantError:     "failure_test.TestFailure: code(1): failure_test.TestFailure: xxx: zzz=true: code(code_a)",
 		},
 		"overwrite": {
-			err: failure.Translate(base, TestCodeB, failure.Messagef("aaa: %s", "bbb"), failure.MessageKV{"ccc": "1", "ddd": "2"}),
+			err: failure.Translate(base, TestCodeB, failure.Messagef("aaa: %s", "bbb"), failure.Context{"ccc": "1", "ddd": "2"}),
 
 			shouldNil:     false,
 			wantCode:      TestCodeB,
@@ -88,7 +88,7 @@ func TestFailure(t *testing.T) {
 			wantError:     io.EOF.Error(),
 		},
 		"unexpected": {
-			err: failure.Unexpected("unexpected error", failure.MessageKV{"aaa": "1"}),
+			err: failure.Unexpected("unexpected error", failure.Context{"aaa": "1"}),
 
 			shouldNil:     false,
 			wantCode:      nil,
@@ -136,7 +136,7 @@ func TestFailure(t *testing.T) {
 
 func TestFailure_Format(t *testing.T) {
 	e1 := fmt.Errorf("yyy")
-	e2 := failure.Translate(e1, TestCodeA, failure.Message("xxx"), failure.MessageKV{"zzz": "true"})
+	e2 := failure.Translate(e1, TestCodeA, failure.Message("xxx"), failure.Context{"zzz": "true"})
 	err := failure.Wrap(e2)
 
 	want := "failure_test.TestFailure_Format: failure_test.TestFailure_Format: xxx: zzz=true: code(code_a): yyy"

--- a/iterator.go
+++ b/iterator.go
@@ -1,17 +1,16 @@
 package failure
 
-// NewIterator creates an iterator for given err.
+// NewIterator creates an iterator for the err.
 func NewIterator(err error) *Iterator {
 	return &Iterator{guardianUnwapper{err}}
 }
 
-// Iterator is designed to iterate errors by unwrapping it
-// with for loop.
+// Iterator is designed to iterate wrapped errors with for loop.
 type Iterator struct {
 	err error
 }
 
-// Next try to unwrap an error and returns whether the next
+// Next tries to unwrap an error and returns whether the next
 // error is present. Since this method updates internal state of the
 // iterator, should be called only once per iteration.
 func (i *Iterator) Next() bool {
@@ -48,7 +47,7 @@ func (w guardianUnwapper) UnwrapError() error {
 	return w.error
 }
 
-// CauseOf returns the most underlying error of err.
+// CauseOf returns a most underlying error of the err.
 func CauseOf(err error) error {
 	if err == nil {
 		return nil

--- a/wrapper.go
+++ b/wrapper.go
@@ -30,7 +30,7 @@ func (f WrapperFunc) WrapError(err error) error {
 	return f(err)
 }
 
-// Message appends error message to an error.
+// Message appends an error message to the err.
 func Message(msg string) Wrapper {
 	return WrapperFunc(func(err error) error {
 		return &withMessage{msg, err}
@@ -61,8 +61,7 @@ func (w *withMessage) GetMessage() string {
 	return w.message
 }
 
-// MessageOf extracts the message from err.
-// Message from MessageKV is not returned.
+// MessageOf extracts a message from the err.
 func MessageOf(err error) (string, bool) {
 	if err == nil {
 		return "", false
@@ -128,8 +127,7 @@ func (m *withContext) GetContext() Context {
 	return m.ctx
 }
 
-// WithCallStackSkip appends call stack to an error
-// skipping top N of frames.
+// WithCallStackSkip appends a call stack to the err skipping first N frames.
 // You don't have to use this directly, unless using function Custom.
 func WithCallStackSkip(skip int) Wrapper {
 	cs := Callers(skip + 1)
@@ -159,7 +157,7 @@ func (w *withCallStack) GetCallStack() CallStack {
 	return w.callStack
 }
 
-// CallStackOf extracts call stack from the error.
+// CallStackOf extracts a call stack from the err.
 // Returned call stack is for the most deepest place (appended first).
 func CallStackOf(err error) (CallStack, bool) {
 	if err == nil {
@@ -185,7 +183,7 @@ func CallStackOf(err error) (CallStack, bool) {
 	return last, true
 }
 
-// WithFormatter appends error formatter to an error.
+// WithFormatter appends an error formatter to the err.
 //
 //     %v+: Print trace for each place, and deepest call stack.
 //     %#v: Print raw structure of the error.
@@ -231,8 +229,8 @@ func (f *formatter) Format(s fmt.State, verb rune) {
 	type callStacker interface {
 		GetCallStack() CallStack
 	}
-	type messageKVer interface {
-		GetMessageKV() MessageKV
+	type contexter interface {
+		GetContext() Context
 	}
 	type messenger interface {
 		GetMessage() string
@@ -250,7 +248,7 @@ func (f *formatter) Format(s fmt.State, verb rune) {
 		switch t := err.(type) {
 		case callStacker:
 			fmt.Fprintf(s, "%+v\n", t.GetCallStack().HeadFrame())
-		case messageKVer:
+		case contexter:
 			kv := t.GetMessageKV()
 			for k, v := range kv {
 				fmt.Fprintf(s, "    %s = %s\n", k, v)

--- a/wrapper.go
+++ b/wrapper.go
@@ -249,7 +249,7 @@ func (f *formatter) Format(s fmt.State, verb rune) {
 		case callStacker:
 			fmt.Fprintf(s, "%+v\n", t.GetCallStack().HeadFrame())
 		case contexter:
-			kv := t.GetMessageKV()
+			kv := t.GetContext()
 			for k, v := range kv {
 				fmt.Fprintf(s, "    %s = %s\n", k, v)
 			}

--- a/wrapper.go
+++ b/wrapper.go
@@ -83,16 +83,16 @@ func MessageOf(err error) (string, bool) {
 	return "", false
 }
 
-// MessageKV is a key-value message appended to an error
-// for debugging purpose. You must not use this data as a part of
-// your application logic. Just print it.
-// If you want to extract MessageKV from error for printing purpose, you can create an
-// interface with method `GetMessageKV() MessageKV` and use it with
-// iterator, like other extraction function (e.g. MessageOf).
-type MessageKV map[string]string
+// Context is a key-value data which describes the how the error occurred
+// for debugging purpose. You must not use context data as a part of your
+// application logic. Just print it.
+// If you want to extract Context from error for printing purpose, you can
+// define an interface with method `GetContext() Context` and use it with
+// iterator, like other extraction functions (see: MessageOf).
+type Context map[string]string
 
 // WrapError implements the Wrapper interface.
-func (m MessageKV) WrapError(err error) error {
+func (m Context) WrapError(err error) error {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -107,25 +107,25 @@ func (m MessageKV) WrapError(err error) error {
 		}
 		fmt.Fprintf(buf, "%s=%s", k, v)
 	}
-	return &withMessageKV{m, buf.String(), err}
+	return &withContext{m, buf.String(), err}
 }
 
-type withMessageKV struct {
-	kv         MessageKV
+type withContext struct {
+	ctx        Context
 	memo       string
 	underlying error
 }
 
-func (m *withMessageKV) Error() string {
+func (m *withContext) Error() string {
 	return fmt.Sprintf("%s: %s", m.memo, m.underlying)
 }
 
-func (m *withMessageKV) UnwrapError() error {
+func (m *withContext) UnwrapError() error {
 	return m.underlying
 }
 
-func (m *withMessageKV) GetMessageKV() MessageKV {
-	return m.kv
+func (m *withContext) GetContext() Context {
+	return m.ctx
 }
 
 // WithCallStackSkip appends call stack to an error


### PR DESCRIPTION
# Changes

Rename `MessageKV` to `Context`.

# Motivation

I have avoided using the name `Context` because of duplication with `context.Context`.
But the name `Context` represents responsibility of the object correctly.