### PR TITLE
Support new As method

### DIFF
--- a/failure.go
+++ b/failure.go
@@ -22,9 +22,9 @@ func CodeOf(err error) (Code, bool) {
 
 	i := NewIterator(err)
 	for i.Next() {
-		err := i.Error()
-		if f, ok := err.(Failure); ok {
-			return f.GetCode(), true
+		var c Code
+		if i.As(&c) {
+			return c, true
 		}
 	}
 
@@ -105,8 +105,17 @@ func (w *withCode) Unwrap() error {
 	return w.underlying
 }
 
+// Deprecated: Please use As method on Iterator.
 func (f *withCode) GetCode() Code {
 	return f.code
+}
+
+func (f *withCode) As(x interface{}) bool {
+	if c, ok := x.(*Code); ok {
+		*c = f.code
+		return true
+	}
+	return false
 }
 
 func (f *withCode) Error() string {

--- a/iterator.go
+++ b/iterator.go
@@ -45,6 +45,17 @@ func (i *Iterator) Error() error {
 	return i.err
 }
 
+// As tries to extract data from current error.
+// It returns true if the current error implemented As and it returned true.
+func (i *Iterator) As(x interface{}) bool {
+	switch t := i.Error().(type) {
+	case interface{ As(interface{}) bool }:
+		return t.As(x)
+	default:
+		return false
+	}
+}
+
 type guardianUnwapper struct {
 	error
 }


### PR DESCRIPTION
# Changes

- Implemented Go 1.13's `As` method for each wrapper
- Deprecated GetXXX method for each wrapper
- Changed the type of `failure.Message` from function to type name
  - This is a breaking change, but in most case, it does not affect to user's code.
- Added `As` on `Iterator`
 
# Motivation

Following to the standard library.