### PR TITLE
Add WithUnexpected instead of WithoutCode

### DIFF
--- a/failure_test.go
+++ b/failure_test.go
@@ -103,7 +103,7 @@ func TestFailure(t *testing.T) {
 			wantCode:      nil,
 			wantMessage:   "xxx",
 			wantStackLine: 17,
-			wantError:     "failure_test.TestFailure: code_eliminated: failure_test.TestFailure: xxx: zzz=true: code(code_a)",
+			wantError:     "failure_test.TestFailure: unexpected: failure_test.TestFailure: xxx: zzz=true: code(code_a)",
 		},
 	}
 

--- a/wrapper.go
+++ b/wrapper.go
@@ -30,6 +30,7 @@ var _ = []interface{ Unwrap() error }{
 	(*formatter)(nil),
 	(*withCode)(nil),
 	(*withoutCode)(nil),
+	(*withUnexpected)(nil),
 }
 
 // Wrapper interface is used by constructor functions.
@@ -327,4 +328,29 @@ func (f *formatter) Format(s fmt.State, verb rune) {
 			fmt.Fprintf(s, "    %+v\n", f)
 		}
 	}
+}
+
+// WithUnexpected wraps the err to mark it is unexpected.
+// You don't have to use this directly, unless using function Custom.
+// Please use Unexpected or MarkUnexpected.
+func WithUnexpected() Wrapper {
+	return WrapperFunc(func(err error) error {
+		return &withUnexpected{err}
+	})
+}
+
+type withUnexpected struct {
+	underlying error
+}
+
+func (w *withUnexpected) Unwrap() error {
+	return w.underlying
+}
+
+func (w *withUnexpected) Error() string {
+	return fmt.Sprintf("unexpected: %s", w.underlying)
+}
+
+func (*withUnexpected) Unexpected() bool {
+	return true
 }


### PR DESCRIPTION
# Changes

- Distinguish unexpected errors by interface.
- Deprecate `WithoutCode`

## Breaking

This change potentially breaks user's code that is directly using `NoCode` interface.
But since (almost) all users should not be using that interface in their code, this change does not affect users.

# Motivation

`WithoutCode` was added for marking an error as unexpected, but having a dedicated interface for unexpected errors lets us use the interface for other purposes like eliminating `failure.Message` propagation.