### PR TITLE
v1 release

### DIFF
--- a/callstack_test.go
+++ b/callstack_test.go
@@ -14,13 +14,13 @@ func X() failure.CallStack {
 func TestCallers(t *testing.T) {
 	fs := X().Frames()
 
-	shouldContain(t, fs[0].Path(), "github.com/morikuni/failure/callstack_test.go")
+	shouldContain(t, fs[0].Path(), "/failure/callstack_test.go")
 	shouldContain(t, fs[0].File(), "callstack_test.go")
 	shouldEqual(t, fs[0].Func(), "X")
 	shouldEqual(t, fs[0].Line(), 11)
 	shouldEqual(t, fs[0].Pkg(), "failure_test")
 
-	shouldContain(t, fs[1].Path(), "github.com/morikuni/failure/callstack_test.go")
+	shouldContain(t, fs[1].Path(), "/failure/callstack_test.go")
 	shouldContain(t, fs[1].File(), "callstack_test.go")
 	shouldEqual(t, fs[1].Func(), "TestCallers")
 	shouldEqual(t, fs[1].Line(), 15)
@@ -40,12 +40,12 @@ func TestCallStack_Format(t *testing.T) {
 	)
 	shouldMatch(t,
 		fmt.Sprintf("%#v", cs),
-		`\[\]failure.Frame{/.+/github.com/morikuni/failure/callstack_test.go:11, /.+/github.com/morikuni/failure/callstack_test.go:31, .*}`,
+		`\[\]failure.Frame{/.+/failure/callstack_test.go:11, /.+/failure/callstack_test.go:31, .*}`,
 	)
 	shouldMatch(t,
 		fmt.Sprintf("%+v", cs),
-		`\[failure_test.X\] /.+/github.com/morikuni/failure/callstack_test.go:11
-\[failure_test.TestCallStack_Format\] /.+/github.com/morikuni/failure/callstack_test.go:31
+		`\[failure_test.X\] /.+/failure/callstack_test.go:11
+\[failure_test.TestCallStack_Format\] /.+/failure/callstack_test.go:31
 \[.*`,
 	)
 }
@@ -55,19 +55,19 @@ func TestFrame_Format(t *testing.T) {
 
 	shouldMatch(t,
 		fmt.Sprintf("%v", f),
-		`/.+/github.com/morikuni/failure/callstack_test.go:11`,
+		`/.+/failure/callstack_test.go:11`,
 	)
 	shouldMatch(t,
 		fmt.Sprintf("%s", f),
-		`/.+/github.com/morikuni/failure/callstack_test.go:11`,
+		`/.+/failure/callstack_test.go:11`,
 	)
 	shouldMatch(t,
 		fmt.Sprintf("%#v", f),
-		`/.+/github.com/morikuni/failure/callstack_test.go:11`,
+		`/.+/failure/callstack_test.go:11`,
 	)
 	shouldMatch(t,
 		fmt.Sprintf("%+v", f),
-		`\[failure_test.X\] /.+/github.com/morikuni/failure/callstack_test.go:11`,
+		`\[failure_test.X\] /.+/failure/callstack_test.go:11`,
 	)
 }
 
@@ -96,6 +96,6 @@ func TestFrame(t *testing.T) {
 	shouldEqual(t, f.Func(), "X")
 	shouldEqual(t, f.Line(), 11)
 	shouldEqual(t, f.File(), "callstack_test.go")
-	shouldContain(t, f.Path(), "github.com/morikuni/failure/callstack_test.go")
+	shouldContain(t, f.Path(), "/failure/callstack_test.go")
 	shouldEqual(t, f.Pkg(), "failure_test")
 }

--- a/failure.go
+++ b/failure.go
@@ -124,11 +124,6 @@ type withCode struct {
 	underlying error
 }
 
-// Deprecated: This function will be deleted in v1.0.0 release. Please use Unwrap.
-func (w *withCode) UnwrapError() error {
-	return w.Unwrap()
-}
-
 func (w *withCode) Unwrap() error {
 	return w.underlying
 }

--- a/failure.go
+++ b/failure.go
@@ -6,13 +6,6 @@ import (
 	"fmt"
 )
 
-// Failure represents an error with error code.
-// Deprecated: This interface will be deleted in v1.0.0 release.
-type Failure interface {
-	error
-	GetCode() Code
-}
-
 // CodeOf extracts an error code from the err.
 // The first error code found in the err is returned, but if Unexpected
 // interface is detected before the code is found, it behaves as if
@@ -102,14 +95,6 @@ func Unexpected(msg string, wrappers ...Wrapper) error {
 	return Custom(Custom(unexpected(msg), wrappers...), WithFormatter(), WithCallStackSkip(1))
 }
 
-// NewFailure returns Failure without any wrappers.
-// You don't have to use this directly, unless using function Custom.
-// Basically, you can use function New instead of this.
-// Deprecated: This function will be deleted in v1.0.0 release. Please use New.
-func NewFailure(code Code) Failure {
-	return &withCode{code: code}
-}
-
 // WithCode appends code to an error.
 // You don't have to use this directly, unless using function Custom.
 // Basically, you can use function Translate instead of this.
@@ -126,11 +111,6 @@ type withCode struct {
 
 func (w *withCode) Unwrap() error {
 	return w.underlying
-}
-
-// Deprecated: This function will be deleted in v1.0.0 release. Please use As method on Iterator.
-func (w *withCode) GetCode() Code {
-	return w.code
 }
 
 func (w *withCode) As(x interface{}) bool {

--- a/failure.go
+++ b/failure.go
@@ -132,29 +132,3 @@ func (w *withCode) Error() string {
 	}
 	return fmt.Sprintf("code(%s): %s", w.code.ErrorCode(), w.underlying)
 }
-
-// WithoutCode prevents propagation of error code from underlying error
-// You don't have to use this directly, unless using function Custom.
-// Basically, you can use function MarkUnexpected instead of this.
-// Deprecated: This function will be deleted in v1.0.0 release. Please use WithUnexpected.
-func WithoutCode() Wrapper {
-	return WrapperFunc(func(err error) error {
-		return &withoutCode{err}
-	})
-}
-
-type withoutCode struct {
-	underlying error
-}
-
-func (w *withoutCode) Unwrap() error {
-	return w.underlying
-}
-
-func (w *withoutCode) Error() string {
-	return fmt.Sprintf("code_eliminated: %s", w.underlying)
-}
-
-func (*withoutCode) NoCode() bool {
-	return true
-}

--- a/failure_test.go
+++ b/failure_test.go
@@ -25,14 +25,14 @@ func TestFailure_Format(t *testing.T) {
 	exp := `&failure.formatter{error:\(\*failure.withCallStack\)\(.*`
 	shouldMatch(t, fmt.Sprintf("%#v", err), exp)
 
-	exp = `\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:19
-\[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:18
+	exp = `\[failure_test.TestFailure_Format\] /.*/failure/failure_test.go:19
+\[failure_test.TestFailure_Format\] /.*/failure/failure_test.go:18
     message\("xxx"\)
     zzz = true
     code\(code_a\)
     \*errors.errorString\("yyy"\)
 \[CallStack\]
-    \[failure_test.TestFailure_Format\] /.*/github.com/morikuni/failure/failure_test.go:18
+    \[failure_test.TestFailure_Format\] /.*/failure/failure_test.go:18
     \[.*`
 	shouldMatch(t, fmt.Sprintf("%+v", err), exp)
 }
@@ -64,7 +64,7 @@ func TestFailure(t *testing.T) {
 			wantStackLine: 59,
 			wantError:     "failure_test.TestFailure: aaa=1: code(code_a)",
 			wantTracer: failure.StringTracer{
-				"\\[TestFailure\\] .+github.com/morikuni/failure/failure_test.go:59",
+				"\\[TestFailure\\] .+/failure/failure_test.go:59",
 				"aaa = 1",
 				"code = code_a",
 			},
@@ -78,9 +78,9 @@ func TestFailure(t *testing.T) {
 			wantStackLine: 47,
 			wantError:     "failure_test.TestFailure: code(1): failure_test.TestFailure: xxx: zzz=true: code(code_a)",
 			wantTracer: failure.StringTracer{
-				"\\[TestFailure\\] .+github.com/morikuni/failure/failure_test.go:73",
+				"\\[TestFailure\\] .+/failure/failure_test.go:73",
 				"code = 1",
-				"\\[TestFailure\\] .+github.com/morikuni/failure/failure_test.go:47",
+				"\\[TestFailure\\] .+/failure/failure_test.go:47",
 				"message = xxx",
 				"zzz = true",
 				"code = code_a",
@@ -95,12 +95,12 @@ func TestFailure(t *testing.T) {
 			wantStackLine: 47,
 			wantError:     "failure_test.TestFailure: aaa: bbb: ccc=1 ddd=2: code(1): failure_test.TestFailure: xxx: zzz=true: code(code_a)",
 			wantTracer: failure.StringTracer{
-				"\\[TestFailure\\] .+github.com/morikuni/failure/failure_test.go:90",
+				"\\[TestFailure\\] .+/failure/failure_test.go:90",
 				"message = aaa: bbb",
 				"ccc = 1",
 				"ddd = 2",
 				"code = 1",
-				"\\[TestFailure\\] .+github.com/morikuni/failure/failure_test.go:47",
+				"\\[TestFailure\\] .+/failure/failure_test.go:47",
 				"message = xxx",
 				"zzz = true",
 				"code = code_a",
@@ -115,7 +115,7 @@ func TestFailure(t *testing.T) {
 			wantStackLine: 110,
 			wantError:     "failure_test.TestFailure: " + io.EOF.Error(),
 			wantTracer: failure.StringTracer{
-				"\\[TestFailure\\] .*github.com/morikuni/failure/failure_test.go:110",
+				"\\[TestFailure\\] .*/failure/failure_test.go:110",
 			},
 		},
 		"wrap nil": {
@@ -157,7 +157,7 @@ func TestFailure(t *testing.T) {
 			wantStackLine: 152,
 			wantError:     "failure_test.TestFailure: aaa=1: unexpected error",
 			wantTracer: failure.StringTracer{
-				"\\[TestFailure\\] .*github.com/morikuni/failure/failure_test.go:152",
+				"\\[TestFailure\\] .*/failure/failure_test.go:152",
 				"aaa = 1",
 				"unexpected: unexpected error",
 			},
@@ -171,9 +171,9 @@ func TestFailure(t *testing.T) {
 			wantStackLine: 47,
 			wantError:     "failure_test.TestFailure: unexpected: failure_test.TestFailure: xxx: zzz=true: code(code_a)",
 			wantTracer: failure.StringTracer{
-				"\\[TestFailure\\] .+github.com/morikuni/failure/failure_test.go:166",
+				"\\[TestFailure\\] .+/failure/failure_test.go:166",
 				"unexpected: mark unexpected",
-				"\\[TestFailure\\] .+github.com/morikuni/failure/failure_test.go:47",
+				"\\[TestFailure\\] .+/failure/failure_test.go:47",
 				"message = xxx",
 				"zzz = true",
 				"code = code_a",
@@ -223,4 +223,3 @@ func TestFailure(t *testing.T) {
 		})
 	}
 }
-

--- a/failure_test.go
+++ b/failure_test.go
@@ -87,18 +87,17 @@ func TestFailure(t *testing.T) {
 			},
 		},
 		"overwrite": {
-			err: failure.Translate(base, TestCodeB, failure.Messagef("aaa: %s", "bbb"), failure.Context{"ccc": "1", "ddd": "2"}),
+			err: failure.Translate(base, TestCodeB, failure.Messagef("aaa: %s", "bbb"), failure.Context{"ccc": "1"}),
 
 			shouldNil:     false,
 			wantCode:      TestCodeB,
 			wantMessage:   "aaa: bbb",
 			wantStackLine: 47,
-			wantError:     "failure_test.TestFailure: aaa: bbb: ccc=1 ddd=2: code(1): failure_test.TestFailure: xxx: zzz=true: code(code_a)",
+			wantError:     "failure_test.TestFailure: aaa: bbb: ccc=1: code(1): failure_test.TestFailure: xxx: zzz=true: code(code_a)",
 			wantTracer: failure.StringTracer{
 				"\\[TestFailure\\] .+/failure/failure_test.go:90",
 				"message = aaa: bbb",
 				"ccc = 1",
-				"ddd = 2",
 				"code = 1",
 				"\\[TestFailure\\] .+/failure/failure_test.go:47",
 				"message = xxx",
@@ -112,10 +111,10 @@ func TestFailure(t *testing.T) {
 			shouldNil:     false,
 			wantCode:      nil,
 			wantMessage:   "",
-			wantStackLine: 110,
+			wantStackLine: 109,
 			wantError:     "failure_test.TestFailure: " + io.EOF.Error(),
 			wantTracer: failure.StringTracer{
-				"\\[TestFailure\\] .*/failure/failure_test.go:110",
+				"\\[TestFailure\\] .*/failure/failure_test.go:109",
 			},
 		},
 		"wrap nil": {
@@ -154,10 +153,10 @@ func TestFailure(t *testing.T) {
 			shouldNil:     false,
 			wantCode:      nil,
 			wantMessage:   "",
-			wantStackLine: 152,
+			wantStackLine: 151,
 			wantError:     "failure_test.TestFailure: aaa=1: unexpected error",
 			wantTracer: failure.StringTracer{
-				"\\[TestFailure\\] .*/failure/failure_test.go:152",
+				"\\[TestFailure\\] .*/failure/failure_test.go:151",
 				"aaa = 1",
 				"unexpected: unexpected error",
 			},
@@ -171,7 +170,7 @@ func TestFailure(t *testing.T) {
 			wantStackLine: 47,
 			wantError:     "failure_test.TestFailure: unexpected: failure_test.TestFailure: xxx: zzz=true: code(code_a)",
 			wantTracer: failure.StringTracer{
-				"\\[TestFailure\\] .+/failure/failure_test.go:166",
+				"\\[TestFailure\\] .+/failure/failure_test.go:165",
 				"unexpected: mark unexpected",
 				"\\[TestFailure\\] .+/failure/failure_test.go:47",
 				"message = xxx",

--- a/iterator.go
+++ b/iterator.go
@@ -28,10 +28,16 @@ func (i *Iterator) unwrapError() error {
 	type go113error interface {
 		Unwrap() error
 	}
+	// For backward compatibility with v0 failure.
+	type oldFailureError interface {
+		UnwrapError() error
+	}
 
 	switch t := i.err.(type) {
 	case go113error:
 		return t.Unwrap()
+	case oldFailureError:
+		return t.UnwrapError()
 	case causer:
 		return t.Cause()
 	}

--- a/iterator.go
+++ b/iterator.go
@@ -32,8 +32,6 @@ func (i *Iterator) unwrapError() error {
 	switch t := i.err.(type) {
 	case go113error:
 		return t.Unwrap()
-	case Unwrapper:
-		return t.UnwrapError()
 	case causer:
 		return t.Cause()
 	}
@@ -60,7 +58,7 @@ type guardianUnwapper struct {
 	error
 }
 
-func (w guardianUnwapper) UnwrapError() error {
+func (w guardianUnwapper) Unwrap() error {
 	return w.error
 }
 

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -12,7 +12,7 @@ type a struct {
 	error
 }
 
-func (a a) UnwrapError() error {
+func (a a) Unwrap() error {
 	return a.error
 }
 
@@ -29,7 +29,7 @@ type c struct {
 	error
 }
 
-func (c c) UnwrapError() error {
+func (c c) Unwrap() error {
 	return c.error
 }
 

--- a/wrapper.go
+++ b/wrapper.go
@@ -141,11 +141,6 @@ func (w *withContext) Unwrap() error {
 	return w.underlying
 }
 
-// Deprecated: This function will be deleted in v1.0.0 release. Please use As method on Iterator.
-func (w *withContext) GetContext() Context {
-	return w.ctx
-}
-
 func (w *withContext) As(x interface{}) bool {
 	switch t := x.(type) {
 	case *Context:

--- a/wrapper.go
+++ b/wrapper.go
@@ -179,11 +179,6 @@ func (w *withCallStack) Unwrap() error {
 	return w.underlying
 }
 
-// Deprecated: This function will be deleted in v1.0.0 release. Please use As method on Iterator.
-func (w *withCallStack) GetCallStack() CallStack {
-	return w.callStack
-}
-
 func (w *withCallStack) As(x interface{}) bool {
 	switch t := x.(type) {
 	case *CallStack:

--- a/wrapper.go
+++ b/wrapper.go
@@ -71,11 +71,6 @@ func (w *withMessage) Unwrap() error {
 	return w.underlying
 }
 
-// Deprecated: This function will be deleted in v1.0.0 release. Please use As method on Iterator.
-func (w *withMessage) GetMessage() string {
-	return w.message.String()
-}
-
 func (w *withMessage) As(x interface{}) bool {
 	switch t := x.(type) {
 	case *Message:

--- a/wrapper.go
+++ b/wrapper.go
@@ -3,26 +3,9 @@ package failure
 import (
 	"bytes"
 	"fmt"
-	"sort"
-
 	"io"
+	"sort"
 )
-
-// Unwrapper interface is used by iterator.
-// Deprecated: Implement interface{ Unwrap() error }.
-type Unwrapper interface {
-	// UnwrapError should return nearest child error.
-	// The returned error can be nil.
-	UnwrapError() error
-}
-
-var _ = []Unwrapper{
-	(*withMessage)(nil),
-	(*withContext)(nil),
-	(*withCallStack)(nil),
-	(*formatter)(nil),
-	(*withCode)(nil),
-}
 
 var _ = []interface{ Unwrap() error }{
 	(*withMessage)(nil),
@@ -82,11 +65,6 @@ type withMessage struct {
 
 func (w *withMessage) Error() string {
 	return fmt.Sprintf("%s: %s", w.message, w.underlying)
-}
-
-// Deprecated: This function will be deleted in v1.0.0 release. Please use Unwrap.
-func (w *withMessage) UnwrapError() error {
-	return w.Unwrap()
 }
 
 func (w *withMessage) Unwrap() error {
@@ -164,11 +142,6 @@ func (w *withContext) Error() string {
 	return fmt.Sprintf("%s: %s", w.memo, w.underlying)
 }
 
-// Deprecated: This function will be deleted in v1.0.0 release. Please use Unwrap.
-func (w *withContext) UnwrapError() error {
-	return w.Unwrap()
-}
-
 func (w *withContext) Unwrap() error {
 	return w.underlying
 }
@@ -210,11 +183,6 @@ type withCallStack struct {
 func (w *withCallStack) Error() string {
 	head := w.callStack.HeadFrame()
 	return fmt.Sprintf("%s.%s: %s", head.Pkg(), head.Func(), w.underlying)
-}
-
-// Deprecated: This function will be deleted in v1.0.0 release. Please use Unwrap.
-func (w *withCallStack) UnwrapError() error {
-	return w.Unwrap()
 }
 
 func (w *withCallStack) Unwrap() error {
@@ -272,11 +240,6 @@ func WithFormatter() Wrapper {
 
 type formatter struct {
 	error
-}
-
-// Deprecated: This function will be deleted in v1.0.0 release. Please use Unwrap.
-func (f *formatter) UnwrapError() error {
-	return f.Unwrap()
 }
 
 func (f *formatter) Unwrap() error {

--- a/wrapper.go
+++ b/wrapper.go
@@ -13,7 +13,6 @@ var _ = []interface{ Unwrap() error }{
 	(*withCallStack)(nil),
 	(*formatter)(nil),
 	(*withCode)(nil),
-	(*withoutCode)(nil),
 	(*withUnexpected)(nil),
 }
 


### PR DESCRIPTION
# Changes

- Removed deprecated symbols.

# Motivation

- Since `failure`  has been stable for more than 1 year, assuming no need to make breaking changes anymore.

# Migration Guideline

For almost all use-cases only following change may be required.

- Replace codes that converts errors into `interface{ GetXXX() YYY } (e.g.  v, ok := err.interface{ GetCode() failure.Code })` with `iterator.As(&v) (e.g. var c failure.Code; iterator.As(&c))`. 

If you're not customizing the `failure`, just using some functions, then you don't  need to worry too much about v1 release.