### PR TITLE
Keep comment up to date for v1

### DIFF
--- a/wrapper.go
+++ b/wrapper.go
@@ -17,8 +17,6 @@ var _ = []interface{ Unwrap() error }{
 }
 
 // Wrapper interface is used by constructor functions.
-// Note: The method of this interface will be replaced by Wrap(error) error
-// in v1.0.0 release to be consistent in errors' Unwrap interface.
 type Wrapper interface {
 	// WrapError should wrap given err to append some
 	// capability to the error.


### PR DESCRIPTION
# Changes

Remove comment for v1.

# Motivation

Originally, I meant to change the signature of the interface to have the consistent name with standard `Unwrap` method. But  now I have decided keep compatibility with v0 for easy migration.