### PR TITLE
Add Messenger/Contexter interface to work Message (and Trace) with errors.As

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 defaults: &defaults
   docker:
-    - image: circleci/golang:1.11
+    - image: circleci/golang:1.13
   working_directory: /go/src/github.com/morikuni/failure
 
 version: 2

--- a/code_test.go
+++ b/code_test.go
@@ -2,9 +2,8 @@ package failure_test
 
 import (
 	"errors"
-	"testing"
-
 	"io"
+	"testing"
 
 	"github.com/morikuni/failure"
 )
@@ -61,4 +60,21 @@ func TestIs(t *testing.T) {
 
 	shouldEqual(t, failure.Is(nil, nil), true)
 	shouldEqual(t, failure.Is(errors.New("error"), nil), true)
+}
+
+func TestErrorsAs(t *testing.T) {
+	const (
+		A failure.StringCode = "A"
+	)
+	err := failure.New(A, failure.Message("foo"))
+	var cs failure.CallStack
+	wantCS, _ := failure.CallStackOf(err)
+	shouldEqual(t, errors.As(err, &cs), true)
+	shouldEqual(t, cs, wantCS)
+	var code failure.Code
+	shouldEqual(t, errors.As(err, &code), true)
+	shouldEqual(t, code, A)
+	var msg failure.Messenger
+	shouldEqual(t, errors.As(err, &msg), true)
+	shouldEqual(t, msg, failure.Message("foo"))
 }

--- a/code_test.go
+++ b/code_test.go
@@ -61,20 +61,3 @@ func TestIs(t *testing.T) {
 	shouldEqual(t, failure.Is(nil, nil), true)
 	shouldEqual(t, failure.Is(errors.New("error"), nil), true)
 }
-
-func TestErrorsAs(t *testing.T) {
-	const (
-		A failure.StringCode = "A"
-	)
-	err := failure.New(A, failure.Message("foo"))
-	var cs failure.CallStack
-	wantCS, _ := failure.CallStackOf(err)
-	shouldEqual(t, errors.As(err, &cs), true)
-	shouldEqual(t, cs, wantCS)
-	var code failure.Code
-	shouldEqual(t, errors.As(err, &code), true)
-	shouldEqual(t, code, A)
-	var msg failure.Messenger
-	shouldEqual(t, errors.As(err, &msg), true)
-	shouldEqual(t, msg, failure.Message("foo"))
-}

--- a/failure.go
+++ b/failure.go
@@ -81,8 +81,8 @@ func (e unexpected) Unexpected() bool {
 
 func (e unexpected) As(x interface{}) bool {
 	switch t := x.(type) {
-	case Tracer:
-		t.Push(e)
+	case *Tracer:
+		(*t).Push(e)
 		return true
 	default:
 		return false
@@ -123,8 +123,8 @@ func (w *withCode) As(x interface{}) bool {
 	case *Code:
 		*t = w.code
 		return true
-	case Tracer:
-		t.Push(w.code)
+	case *Tracer:
+		(*t).Push(w.code)
 		return true
 	default:
 		return false

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/morikuni/failure
 
-go 1.12
+go 1.13

--- a/tracer.go
+++ b/tracer.go
@@ -13,7 +13,7 @@ func Trace(err error, vs Tracer) {
 
 	i := NewIterator(err)
 	for i.Next() {
-		i.As(vs)
+		i.As(&vs)
 	}
 }
 

--- a/wrapper.go
+++ b/wrapper.go
@@ -90,8 +90,8 @@ func (w *withMessage) As(x interface{}) bool {
 	case *Messenger:
 		*t = w.message
 		return true
-	case Tracer:
-		t.Push(w.message)
+	case *Tracer:
+		(*t).Push(w.message)
 		return true
 	}
 	return false
@@ -161,8 +161,8 @@ func (w *withContext) As(x interface{}) bool {
 	case *Context:
 		*t = w.ctx
 		return true
-	case Tracer:
-		t.Push(w.ctx)
+	case *Tracer:
+		(*t).Push(w.ctx)
 		return true
 	}
 	return false
@@ -204,8 +204,8 @@ func (w *withCallStack) As(x interface{}) bool {
 	case *CallStack:
 		*t = w.callStack
 		return true
-	case Tracer:
-		t.Push(w.callStack)
+	case *Tracer:
+		(*t).Push(w.callStack)
 		return true
 	}
 	return false
@@ -340,8 +340,8 @@ func (*withUnexpected) Unexpected() bool {
 
 func (*withUnexpected) As(x interface{}) bool {
 	switch t := x.(type) {
-	case Tracer:
-		t.Push(unexpected("mark unexpected"))
+	case *Tracer:
+		(*t).Push(unexpected("mark unexpected"))
 		return true
 	default:
 		return false

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -1,0 +1,53 @@
+package failure_test
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/morikuni/failure"
+)
+
+type errorsAsDelegateError struct {
+	err error
+}
+
+func (errorsAsDelegateError) Error() string {
+	return "errors.As delegate error"
+}
+
+func (err errorsAsDelegateError) As(target interface{}) bool {
+	return errors.As(err.err, target)
+}
+
+func TestErrorsAs(t *testing.T) {
+	const (
+		A failure.StringCode = "A"
+	)
+	err := failure.Translate(errorsAsDelegateError{io.EOF}, A, failure.Message("foo"))
+	var cs failure.CallStack
+	wantCS, ok := failure.CallStackOf(err)
+	shouldEqual(t, ok, true)
+	shouldEqual(t, errors.As(err, &cs), true)
+	shouldEqual(t, cs, wantCS)
+	var code failure.Code
+	shouldEqual(t, errors.As(err, &code), true)
+	shouldEqual(t, code, A)
+	var msg failure.Messenger
+	shouldEqual(t, errors.As(err, &msg), true)
+	shouldEqual(t, msg, failure.Message("foo"))
+	var tracer failure.StringTracer
+	var tracerInterface failure.Tracer = &tracer
+	shouldEqual(t, errors.As(err, &tracerInterface), true)
+	shouldEqual(t, len(tracer), 1)
+
+	code, ok = failure.CodeOf(err)
+	shouldEqual(t, ok, true)
+	shouldEqual(t, code, A)
+	m, ok := failure.MessageOf(err)
+	shouldEqual(t, ok, true)
+	shouldEqual(t, m, "foo")
+	tracer = nil
+	failure.Trace(err, &tracer)
+	shouldEqual(t, len(tracer), 3)
+}


### PR DESCRIPTION
# Changes

- Add Messenger/Contexer interface to work with errors.As.
- Use pointer internally for Tracer.
- Drop support Go 1.11 and 1.12 because they don't have errors.As method.

# Motivation

To be compatible with the standard errors way.

`failure.MessageOf` and `failure.Trace` could panic when an error in the error chain calls `errors.As` in `As(interface{}) bool` function to delegate to internal errors.

# ⚠️ Breaking Change ⚠️

If you implements `As(interface{}) bool` in your `error` and using type switch with `case failure.Tracer`, then you should change it to `case *failure.Tracer` (use pointer).