### PR TITLE
Fix Frame.PkgPath for closures

### DIFF
--- a/callstack.go
+++ b/callstack.go
@@ -144,7 +144,11 @@ func (f frame) Func() string {
 }
 
 func (f frame) PkgPath() string {
-	return f.function[:strings.LastIndex(f.function, ".")]
+	// e.g.
+	//   When f.function = github.com/morikuni/failure_test.TestFrame.func1.1
+	//   f.PkgPath() = github.com/morikuni/failure_test
+	lastSlash := strings.LastIndex(f.function, "/")
+	return f.function[:strings.Index(f.function[lastSlash:], ".")+lastSlash]
 }
 
 func (f frame) PC() uintptr {

--- a/callstack_test.go
+++ b/callstack_test.go
@@ -93,10 +93,14 @@ func TestCallStack_HeadFrame(t *testing.T) {
 }
 
 func TestFrame(t *testing.T) {
-	f := X().HeadFrame()
+	f := func() failure.Frame {
+		return func() failure.Frame {
+			return failure.Callers(0).HeadFrame()
+		}()
+	}()
 
-	shouldEqual(t, f.Func(), "X")
-	shouldEqual(t, f.Line(), 11)
+	shouldEqual(t, f.Func(), "TestFrame.func1.1")
+	shouldEqual(t, f.Line(), 98)
 	shouldEqual(t, f.File(), "callstack_test.go")
 	shouldContain(t, f.Path(), "/failure/callstack_test.go")
 	shouldEqual(t, f.Pkg(), "failure_test")


### PR DESCRIPTION
# Changes

- Fix bug of `Frame.PkgPath()` inside closures.

# Motivation

`PkgPath` for a function `github.com/morikuni/failure_test.TestFrame.func1.1` was `github.com/morikuni/failure_test.TestFrame.func1` with current version. It should be `github.com/morikuni/failure_test`.
