### PR TITLE
Fix Frame.PkgPath for standard package

### DIFF
--- a/callstack.go
+++ b/callstack.go
@@ -148,6 +148,9 @@ func (f frame) PkgPath() string {
 	//   When f.function = github.com/morikuni/failure_test.TestFrame.func1.1
 	//   f.PkgPath() = github.com/morikuni/failure_test
 	lastSlash := strings.LastIndex(f.function, "/")
+	if lastSlash == -1 {
+		lastSlash = 0
+	}
 	return f.function[:strings.Index(f.function[lastSlash:], ".")+lastSlash]
 }
 


### PR DESCRIPTION
# Changes

- Fix `Frame.PkgPath` for standard package.

# Motivation

It panics with standard package (no slash containing).